### PR TITLE
Feature/#6 - API 공통 응답 포맷 구현

### DIFF
--- a/src/main/java/com/api/readinglog/common/response/Response.java
+++ b/src/main/java/com/api/readinglog/common/response/Response.java
@@ -1,0 +1,37 @@
+package com.api.readinglog.common.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public class Response<T> {
+
+    private int code; // 상태 코드: 200, 400, 404, 500....
+
+    private String message; // 응답 메세지
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T data;
+
+    // 응답 성공 (응답 데이터가 없는 경우)
+    public static Response<Void> success(HttpStatus code, String message) {
+        return new Response<>(code.value(), message, null);
+    }
+
+    // 응답 성공 (응답 데이터가 있는 경우)
+    public static <T> Response<T> success(HttpStatus code, String message, T data) {
+        return new Response<>(code.value(), message, data);
+    }
+
+    public static Response<Void> error(HttpStatus code, String message) {
+        return new Response<>(code.value(), message, null);
+    }
+
+    public static <T> Response<T> error(HttpStatus code, T data) {
+        return new Response<>(code.value(), null, data);
+    }
+}

--- a/src/main/java/com/api/readinglog/domain/member/controller/MemberController.java
+++ b/src/main/java/com/api/readinglog/domain/member/controller/MemberController.java
@@ -1,0 +1,30 @@
+package com.api.readinglog.domain.member.controller;
+
+import com.api.readinglog.common.response.Response;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/members")
+public class MemberController {
+
+    // TODO: API 응답 예제 - 보고 나서 지워주시면 됩니다!!
+    @GetMapping("/api-test1")
+    public Response<Void> testApi01() {
+        return Response.success(HttpStatus.OK, "응답 데이터가 없는 API 통신!");
+    }
+
+    @GetMapping("/api-test2")
+    public Response<List<String>> testApi02() {
+        List<String> members = new ArrayList<>();
+        members.add("member1");
+        members.add("member1");
+        members.add("member1");
+
+        return Response.success(HttpStatus.OK, "회원 목록 조회 성공!", members);
+    }
+}

--- a/src/main/java/com/api/readinglog/domain/member/entity/Member.java
+++ b/src/main/java/com/api/readinglog/domain/member/entity/Member.java
@@ -1,4 +1,4 @@
-package com.api.readinglog.domain.entity;
+package com.api.readinglog.domain.member.entity;
 
 import com.api.readinglog.common.base.BaseTimeEntity;
 import jakarta.persistence.Column;

--- a/src/main/java/com/api/readinglog/domain/member/entity/MemberRole.java
+++ b/src/main/java/com/api/readinglog/domain/member/entity/MemberRole.java
@@ -1,4 +1,4 @@
-package com.api.readinglog.domain.entity;
+package com.api.readinglog.domain.member.entity;
 
 import lombok.Getter;
 

--- a/src/main/java/com/api/readinglog/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/api/readinglog/domain/member/repository/MemberRepository.java
@@ -1,6 +1,6 @@
-package com.api.readinglog.domain.repository;
+package com.api.readinglog.domain.member.repository;
 
-import com.api.readinglog.domain.entity.Member;
+import com.api.readinglog.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {

--- a/src/test/java/com/api/readinglog/domain/entity/MemberTest.java
+++ b/src/test/java/com/api/readinglog/domain/entity/MemberTest.java
@@ -1,8 +1,8 @@
 package com.api.readinglog.domain.entity;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import com.api.readinglog.domain.repository.MemberRepository;
+import com.api.readinglog.domain.member.entity.Member;
+import com.api.readinglog.domain.member.entity.MemberRole;
+import com.api.readinglog.domain.member.repository.MemberRepository;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
## ✨ 관련 이슈

- closed #6 

## ✅ 작업 상세 내용

- [x] API 응답 포맷 구현
- [x] 회원 도메인 패키지 변경

## 📌 특이사항
- 예외 처리는 아직 안했습니다!

## 📃 참고 레퍼런스
- https://don9min.vercel.app/blog/springboot/rest-api-response
