### PR TITLE
회원가입, 로그인 기능 리팩토링

### DIFF
--- a/src/main/java/com/api/readinglog/common/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/api/readinglog/common/oauth/CustomOAuth2UserService.java
@@ -1,5 +1,6 @@
 package com.api.readinglog.common.oauth;
 
+import com.api.readinglog.domain.member.entity.MemberRole;
 import java.util.Collections;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -23,16 +24,16 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         OAuth2User oAuth2User = oAuth2UserService.loadUser(userRequest);
 
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
-        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
-        log.debug("플랫폼 아이디: {}", registrationId);
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint()
+                .getUserNameAttributeName();
 
-        OAuth2Attribute oAuth2Attribute = OAuth2Attribute.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
-        log.debug("소셜 로그인 정보: {}", oAuth2Attribute);
+        OAuth2Attribute oAuth2Attribute = OAuth2Attribute.of(registrationId, userNameAttributeName,
+                oAuth2User.getAttributes());
 
         Map<String, Object> memberAttribute = oAuth2Attribute.convertToMap();
 
-        return new DefaultOAuth2User(Collections.singleton(new SimpleGrantedAuthority("ROLE_MEMBER")),
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(MemberRole.of(registrationId).name())),
                 memberAttribute, "email");
-
     }
 }

--- a/src/main/java/com/api/readinglog/common/security/CustomUserDetailsService.java
+++ b/src/main/java/com/api/readinglog/common/security/CustomUserDetailsService.java
@@ -1,8 +1,12 @@
 package com.api.readinglog.common.security;
 
 import com.api.readinglog.domain.member.entity.Member;
+import com.api.readinglog.domain.member.entity.MemberRole;
 import com.api.readinglog.domain.member.repository.MemberRepository;
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -17,16 +21,19 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        return memberRepository.findByEmail(email)
-                .map(this::createUserDetails)
+        Member member = memberRepository.findByEmailAndRole(email, MemberRole.MEMBER_NORMAL)
                 .orElseThrow(() -> new UsernameNotFoundException("해당하는 회원을 찾을 수 없습니다."));
+
+        // 권한 설정 후 UserDetails 객체 생성 및 반환
+        GrantedAuthority authority = new SimpleGrantedAuthority(member.getRole().name());
+        return new User(member.getEmail(), member.getPassword(), Collections.singleton(authority));
     }
 
-    private UserDetails createUserDetails(Member member) {
-        return User.builder()
-                .username(member.getEmail())
-                .password(member.getPassword())
-                .roles(member.getRole().name())
-                .build();
-    }
+//    private UserDetails createUserDetails(Member member) {
+//        return User.builder()
+//                .username(member.getEmail())
+//                .password(member.getPassword())
+//                .roles(member.getRole().name())
+//                .build();
+//    }
 }

--- a/src/main/java/com/api/readinglog/domain/member/controller/MemberController.java
+++ b/src/main/java/com/api/readinglog/domain/member/controller/MemberController.java
@@ -6,8 +6,8 @@ import com.api.readinglog.domain.member.controller.dto.JoinRequest;
 import com.api.readinglog.domain.member.controller.dto.LoginRequest;
 import com.api.readinglog.domain.member.controller.dto.LoginResponse;
 import com.api.readinglog.domain.member.entity.Member;
+import com.api.readinglog.domain.member.entity.MemberRole;
 import com.api.readinglog.domain.member.service.MemberService;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -39,10 +39,11 @@ public class MemberController {
         return Response.success(HttpStatus.OK, "로그인 성공!", LoginResponse.of(jwtToken));
     }
 
-    @GetMapping
-    public Response<Member> my(Authentication authentication) {
+    @GetMapping("/me")
+    public Response<Member> findMember(Authentication authentication) {
         String email = authentication.getName();
-        Member member = memberService.getMemberByEmail(email);
+        String roleName = authentication.getAuthorities().iterator().next().getAuthority();
+        Member member = memberService.getMemberByEmailAndRole(email, MemberRole.valueOf(roleName));
         return Response.success(HttpStatus.OK, "회원 조회 성공!", member);
     }
 

--- a/src/main/java/com/api/readinglog/domain/member/entity/Member.java
+++ b/src/main/java/com/api/readinglog/domain/member/entity/Member.java
@@ -68,7 +68,7 @@ public class Member extends BaseTimeEntity {
                 .nickname(request.getNickname())
                 .password(password)
                 .profileImg(request.getProfileImage().getOriginalFilename())
-                .role(MemberRole.MEMBER)
+                .role(MemberRole.MEMBER_NORMAL)
                 .build();
     }
 

--- a/src/main/java/com/api/readinglog/domain/member/entity/MemberRole.java
+++ b/src/main/java/com/api/readinglog/domain/member/entity/MemberRole.java
@@ -1,10 +1,24 @@
 package com.api.readinglog.domain.member.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public enum MemberRole {
 
-    MEMBER,
+    MEMBER_NORMAL,
+    MEMBER_GOOGLE,
+    MEMBER_KAKAO,
+    MEMBER_NAVER,
     ADMIN;
+
+    public static MemberRole of(String provider) {
+        return switch (provider.toLowerCase()) {
+            case "google" -> MEMBER_GOOGLE;
+            case "kakao" -> MEMBER_KAKAO;
+            case "naver" -> MEMBER_NAVER;
+            default -> MEMBER_NORMAL;
+        };
+    }
 }

--- a/src/main/java/com/api/readinglog/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/api/readinglog/domain/member/repository/MemberRepository.java
@@ -1,9 +1,11 @@
 package com.api.readinglog.domain.member.repository;
 
 import com.api.readinglog.domain.member.entity.Member;
+import com.api.readinglog.domain.member.entity.MemberRole;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+    Optional<Member> findByEmailAndRole(String email, MemberRole role);
 }

--- a/src/main/java/com/api/readinglog/domain/member/service/MemberService.java
+++ b/src/main/java/com/api/readinglog/domain/member/service/MemberService.java
@@ -5,8 +5,10 @@ import com.api.readinglog.common.jwt.JwtTokenProvider;
 import com.api.readinglog.domain.member.controller.dto.JoinRequest;
 import com.api.readinglog.domain.member.controller.dto.LoginRequest;
 import com.api.readinglog.domain.member.entity.Member;
+import com.api.readinglog.domain.member.entity.MemberRole;
 import com.api.readinglog.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class MemberService {
 
     private final MemberRepository memberRepository;
@@ -26,7 +29,7 @@ public class MemberService {
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
     public void join(JoinRequest request) {
-        memberRepository.findByEmail(request.getEmail()).ifPresent(it -> {
+        memberRepository.findByEmailAndRole(request.getEmail(), MemberRole.MEMBER_NORMAL).ifPresent(it -> {
             throw new RuntimeException("이미 존재하는 회원입니다.");
         });
 
@@ -40,7 +43,7 @@ public class MemberService {
         String encodedPassword = passwordEncoder.encode(password);
         Member member = Member.of(request, encodedPassword);
 
-        /* TODO: 이미지 파일 S3에 업로드*/
+        /* TODO: 이미지 파일 S3에 업로드 로직 추가 예정 */
 
         memberRepository.save(member);
     }
@@ -54,8 +57,8 @@ public class MemberService {
 
     }
 
-    public Member getMemberByEmail(String email) {
-        return memberRepository.findByEmail(email)
+    public Member getMemberByEmailAndRole(String email, MemberRole role) {
+        return memberRepository.findByEmailAndRole(email, role)
                 .orElseThrow(() -> new UsernameNotFoundException("회원 정보가 없습니다."));
     }
 }

--- a/src/test/java/com/api/readinglog/domain/entity/MemberTest.java
+++ b/src/test/java/com/api/readinglog/domain/entity/MemberTest.java
@@ -20,7 +20,7 @@ class MemberTest {
     @Test
     @Transactional
     public void test() {
-        Member member = Member.of("test@test.com", "test", "test", MemberRole.MEMBER);
+        Member member = Member.of("test@test.com", "test", "test", MemberRole.MEMBER_NORMAL);
 
         Member saveMember = repository.save(member);
         repository.delete(saveMember);


### PR DESCRIPTION
## ✨ 관련 이슈

- closed #18 

## ✅ 작업 상세 내용

- [x] MemberRole에 `Member_GOOGLE`, `Member_KAKAO`, `Member_NAVER` 정보 추가
- [x] 로그인 한 플랫폼에 따라 회원 `Role`이 결정
- [x] 이메일 로그인을 한 경우에는 `Member_NORMAL`로 저장
- [x] 회원 조회 로직 변경 (`findByEmail` 👉 `findByEmailAndRole`)
