### PR TITLE
UserDeatil 커스텀

### DIFF
--- a/src/main/java/com/api/readinglog/common/security/CustomUserDetail.java
+++ b/src/main/java/com/api/readinglog/common/security/CustomUserDetail.java
@@ -1,0 +1,18 @@
+package com.api.readinglog.common.security;
+
+import com.api.readinglog.domain.member.entity.Member;
+import java.util.Collection;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+@Getter
+public class CustomUserDetail extends User {
+
+    private final Long id;
+
+    public CustomUserDetail(String username, String password, Long id, Collection<? extends GrantedAuthority> authorities) {
+        super(username, password, authorities);
+        this.id = id;
+    }
+}

--- a/src/main/java/com/api/readinglog/common/security/CustomUserDetailsService.java
+++ b/src/main/java/com/api/readinglog/common/security/CustomUserDetailsService.java
@@ -5,6 +5,7 @@ import com.api.readinglog.domain.member.entity.MemberRole;
 import com.api.readinglog.domain.member.repository.MemberRepository;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -14,6 +15,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
@@ -21,19 +23,13 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        log.debug("일반 로그인 시작: {}", email);
+
         Member member = memberRepository.findByEmailAndRole(email, MemberRole.MEMBER_NORMAL)
                 .orElseThrow(() -> new UsernameNotFoundException("해당하는 회원을 찾을 수 없습니다."));
-
         // 권한 설정 후 UserDetails 객체 생성 및 반환
         GrantedAuthority authority = new SimpleGrantedAuthority(member.getRole().name());
-        return new User(member.getEmail(), member.getPassword(), Collections.singleton(authority));
+        // User가 아닌 CustomUserDetail 반환
+        return new CustomUserDetail(member.getEmail(), member.getPassword(), member.getId(), Collections.singleton(authority));
     }
-
-//    private UserDetails createUserDetails(Member member) {
-//        return User.builder()
-//                .username(member.getEmail())
-//                .password(member.getPassword())
-//                .roles(member.getRole().name())
-//                .build();
-//    }
 }

--- a/src/main/java/com/api/readinglog/domain/book/controller/BookController.java
+++ b/src/main/java/com/api/readinglog/domain/book/controller/BookController.java
@@ -1,6 +1,7 @@
 package com.api.readinglog.domain.book.controller;
 
 import com.api.readinglog.common.response.Response;
+import com.api.readinglog.common.security.CustomUserDetail;
 import com.api.readinglog.domain.book.dto.BookSearchApiResponse;
 import com.api.readinglog.domain.book.service.BookService;
 import lombok.RequiredArgsConstructor;
@@ -8,8 +9,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,5 +30,11 @@ public class BookController {
                                                        @RequestParam(defaultValue = "1") int start) {
         
         return Response.success(HttpStatus.OK, "책 검색 성공", bookService.searchBooks(query, start));
+    }
+
+    @PostMapping
+    public Response<Void> registerBook(@AuthenticationPrincipal CustomUserDetail user) {
+        // TODO: 책 등록
+        return Response.success(HttpStatus.CREATED, "책 등록 성공");
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- closed #26 

## ✅ 작업 상세 내용
- 이메일 중복이 허용되기 때문에 토큰에서 꺼내온 이메일로 회원 조회를 하는 코드가 너무 길어짐.
- 식별자인 id 값을 가져와서 이메일 중복 여부와 상관없이 조회하기 위해 토큰 생성시 회원 id 추가
- [x] CustomUserDetail 클래스 구현
- [x] loadByUsername() 수정
- [x] token claims에 회원 id 추가

## 📌 특이사항
- `@AuthenticationPrincipal` 사용해서 사용자 데이터 가져오기 가능!

## 📃 참고 레퍼런스
- https://sjh9708.tistory.com/84
