### PR TITLE
회원가입 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,26 +22,35 @@ repositories {
 }
 
 dependencies {
+	/* Spring Boot Starter */
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	// webclient
+	/* Lombok */
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	/* Web Client */
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-	// jwt
+	/* Database */
+	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	/* Testing */
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
+
+	/* AWS S3 */
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	/* JWT */
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/api/readinglog/common/aws/AmazonS3Config.java
+++ b/src/main/java/com/api/readinglog/common/aws/AmazonS3Config.java
@@ -1,0 +1,34 @@
+package com.api.readinglog.common.aws;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AmazonS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 s3client() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/com/api/readinglog/common/aws/AmazonS3Service.java
+++ b/src/main/java/com/api/readinglog/common/aws/AmazonS3Service.java
@@ -1,0 +1,57 @@
+package com.api.readinglog.common.aws;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.api.readinglog.common.exception.ErrorCode;
+import com.api.readinglog.common.exception.custom.AwsS3Exception;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AmazonS3Service {
+
+    private final AmazonS3 s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadFile(MultipartFile profileImage) {
+        String fileName = generateFileName(profileImage.getOriginalFilename());
+
+        try {
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentLength(profileImage.getSize());
+            metadata.setContentType(profileImage.getContentType());
+
+            uploadToS3(bucket, fileName, profileImage, metadata);
+            return getFileUrl(fileName);
+
+        } catch (IOException e) {
+            throw new AwsS3Exception(ErrorCode.AWS_S3_FILE_UPLOAD_FAIL);
+        }
+    }
+
+    private String generateFileName(String originalFileName) {
+        String currentDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        return String.format("members/%s/%s", currentDate, originalFileName);
+    }
+
+    private void uploadToS3(String bucket, String fileName, MultipartFile file, ObjectMetadata metadata)
+            throws IOException {
+        s3Client.putObject(new PutObjectRequest(bucket, fileName, file.getInputStream(), metadata));
+    }
+
+    private String getFileUrl(String fileName) {
+        return s3Client.getUrl(bucket, fileName).toString();
+    }
+
+}

--- a/src/main/java/com/api/readinglog/common/exception/ErrorCode.java
+++ b/src/main/java/com/api/readinglog/common/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     // 409
     MEMBER_ALREADY_EXISTS("이미 존재하는 회원입니다.", HttpStatus.CONFLICT),
     NICKNAME_ALREADY_EXISTS("이미 존재하는 닉네임입니다.", HttpStatus.CONFLICT),
+    AWS_S3_FILE_UPLOAD_FAIL("AWS S3 파일 업로드에 실패했습니다.", HttpStatus.CONFLICT),
 
     // 500
     INTERNAL_SERVER_ERROR("서버 에러 발생!", HttpStatus.INTERNAL_SERVER_ERROR),;

--- a/src/main/java/com/api/readinglog/common/exception/ErrorCode.java
+++ b/src/main/java/com/api/readinglog/common/exception/ErrorCode.java
@@ -8,11 +8,18 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
 
+    // 400
+    PASSWORD_MISMATCH("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+
+    // 401
+    UNAUTHORIZED_LOGIN("로그인 실패: 인증에 실패하였습니다.", HttpStatus.UNAUTHORIZED),
+
     // 404
-    NOT_FOUND_MEMBER("회원이 존재하지 않습니다!", HttpStatus.NOT_FOUND),
-    MEMBER_ALREADY_EXISTS("이미 존재하는 회원입니다.", HttpStatus.NOT_FOUND),
-    NICKNAME_ALREADY_EXISTS("이미 존재하는 닉네임입니다.", HttpStatus.NOT_FOUND),
-    PASSWORD_MISMATCH("비밀번호가 일치하지 않습니다", HttpStatus.BAD_REQUEST),
+    NOT_FOUND_MEMBER("존재하지 않은 회원입니다.", HttpStatus.NOT_FOUND),
+
+    // 409
+    MEMBER_ALREADY_EXISTS("이미 존재하는 회원입니다.", HttpStatus.CONFLICT),
+    NICKNAME_ALREADY_EXISTS("이미 존재하는 닉네임입니다.", HttpStatus.CONFLICT),
 
     // 500
     INTERNAL_SERVER_ERROR("서버 에러 발생!", HttpStatus.INTERNAL_SERVER_ERROR),;

--- a/src/main/java/com/api/readinglog/common/exception/ErrorCode.java
+++ b/src/main/java/com/api/readinglog/common/exception/ErrorCode.java
@@ -10,6 +10,9 @@ public enum ErrorCode {
 
     // 404
     NOT_FOUND_MEMBER("회원이 존재하지 않습니다!", HttpStatus.NOT_FOUND),
+    MEMBER_ALREADY_EXISTS("이미 존재하는 회원입니다.", HttpStatus.NOT_FOUND),
+    NICKNAME_ALREADY_EXISTS("이미 존재하는 닉네임입니다.", HttpStatus.NOT_FOUND),
+    PASSWORD_MISMATCH("비밀번호가 일치하지 않습니다", HttpStatus.BAD_REQUEST),
 
     // 500
     INTERNAL_SERVER_ERROR("서버 에러 발생!", HttpStatus.INTERNAL_SERVER_ERROR),;

--- a/src/main/java/com/api/readinglog/common/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/com/api/readinglog/common/exception/GlobalExceptionAdvice.java
@@ -2,10 +2,14 @@ package com.api.readinglog.common.exception;
 
 import com.api.readinglog.common.response.Response;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
@@ -31,6 +35,20 @@ public class GlobalExceptionAdvice {
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(Response.error(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
+    }
+
+    // MethodArgumentNotValidException 예외 핸들러
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<Response<List<String>>> handleValidationExceptions(MethodArgumentNotValidException e) {
+        List<String> errors = new ArrayList<>();
+        e.getBindingResult().getAllErrors().forEach((error) -> {
+            String errorMessage = error.getDefaultMessage();
+            errors.add(errorMessage);
+        });
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(Response.error(HttpStatus.BAD_REQUEST, "Input value validation failed", errors));
     }
 
 }

--- a/src/main/java/com/api/readinglog/common/exception/custom/AwsS3Exception.java
+++ b/src/main/java/com/api/readinglog/common/exception/custom/AwsS3Exception.java
@@ -1,0 +1,10 @@
+package com.api.readinglog.common.exception.custom;
+
+import com.api.readinglog.common.exception.CustomException;
+import com.api.readinglog.common.exception.ErrorCode;
+
+public class AwsS3Exception extends CustomException {
+    public AwsS3Exception(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/api/readinglog/common/response/Response.java
+++ b/src/main/java/com/api/readinglog/common/response/Response.java
@@ -31,4 +31,8 @@ public class Response<T> {
         return new Response<>(code.value(), message, null);
     }
 
+    public static<T> Response<T> error(HttpStatus code, String message, T data) {
+        return new Response<>(code.value(), message, data);
+    }
+
 }

--- a/src/main/java/com/api/readinglog/domain/member/controller/MemberController.java
+++ b/src/main/java/com/api/readinglog/domain/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.api.readinglog.domain.member.controller.dto.LoginResponse;
 import com.api.readinglog.domain.member.entity.Member;
 import com.api.readinglog.domain.member.entity.MemberRole;
 import com.api.readinglog.domain.member.service.MemberService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -28,7 +29,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/join")
-    public Response<Void> join(@ModelAttribute JoinRequest request) {
+    public Response<Void> join(@ModelAttribute @Valid JoinRequest request) {
         memberService.join(request);
         return Response.success(HttpStatus.CREATED, "회원 가입 완료");
     }

--- a/src/main/java/com/api/readinglog/domain/member/controller/dto/JoinRequest.java
+++ b/src/main/java/com/api/readinglog/domain/member/controller/dto/JoinRequest.java
@@ -3,6 +3,7 @@ package com.api.readinglog.domain.member.controller.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -14,13 +15,16 @@ import org.springframework.web.multipart.MultipartFile;
 public class JoinRequest {
 
     @NotBlank(message = "이메일은 필수 입력 값입니다.")
-    @Email( message = "이메일 형식이 올바르지 않습니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     private String email;
 
     @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+    @Size(max = 8, message = "닉네임은 8자 이하로 입력해야 합니다.")
+    @Pattern(regexp = "^[\\p{L}0-9]+$", message = "닉네임에는 특수 문자를 사용할 수 없습니다.")
     private String nickname;
 
     @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&]).{8,20}$", message = "비밀번호는 8~20자의 영문 대소문자, 숫자, 특수문자를 포함해야 합니다.")
     private String password;
 
     @NotBlank(message = "비밀번호 확인은 필수입니다.")

--- a/src/main/java/com/api/readinglog/domain/member/controller/dto/JoinRequest.java
+++ b/src/main/java/com/api/readinglog/domain/member/controller/dto/JoinRequest.java
@@ -1,5 +1,8 @@
 package com.api.readinglog.domain.member.controller.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -10,9 +13,17 @@ import org.springframework.web.multipart.MultipartFile;
 @ToString
 public class JoinRequest {
 
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email( message = "이메일 형식이 올바르지 않습니다.")
     private String email;
+
+    @NotBlank(message = "닉네임은 필수 입력 값입니다.")
     private String nickname;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
     private String password;
+
+    @NotBlank(message = "비밀번호 확인은 필수입니다.")
     private String passwordConfirm;
     private MultipartFile profileImage;
 }

--- a/src/main/java/com/api/readinglog/domain/member/entity/Member.java
+++ b/src/main/java/com/api/readinglog/domain/member/entity/Member.java
@@ -62,12 +62,12 @@ public class Member extends BaseTimeEntity {
                 .build();
     }
 
-    public static Member of(JoinRequest request, String password) {
+    public static Member of(JoinRequest request, String password, String profileImgUrl) {
         return Member.builder()
                 .email(request.getEmail())
                 .nickname(request.getNickname())
                 .password(password)
-                .profileImg(request.getProfileImage().getOriginalFilename())
+                .profileImg(profileImgUrl)
                 .role(MemberRole.MEMBER_NORMAL)
                 .build();
     }

--- a/src/main/java/com/api/readinglog/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/api/readinglog/domain/member/repository/MemberRepository.java
@@ -6,6 +6,6 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
     Optional<Member> findByEmailAndRole(String email, MemberRole role);
+    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/com/api/readinglog/domain/member/service/MemberService.java
+++ b/src/main/java/com/api/readinglog/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.api.readinglog.domain.member.service;
 
+import com.api.readinglog.common.aws.AmazonS3Service;
 import com.api.readinglog.common.exception.ErrorCode;
 import com.api.readinglog.common.exception.custom.MemberException;
 import com.api.readinglog.common.jwt.JwtToken;
@@ -19,6 +20,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -30,16 +32,17 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final AmazonS3Service amazonS3Service;
 
     public void join(JoinRequest request) {
         validateExistingMember(request.getEmail(), request.getNickname());
         validatePassword(request.getPassword(), request.getPasswordConfirm());
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
-        Member member = Member.of(request, encodedPassword);
+        String uploadFileUrl = determineProfileImageUrl(request.getProfileImage());
 
-        /* TODO: 이미지 파일 S3에 업로드 로직 추가 예정 */
-
+        Member member = Member.of(request, encodedPassword, uploadFileUrl);
+        log.debug("회원 프로필 사진 객체 URL: {}", uploadFileUrl);
         memberRepository.save(member);
     }
 
@@ -52,16 +55,6 @@ public class MemberService {
     public Member getMemberByEmailAndRole(String email, MemberRole role) {
         return memberRepository.findByEmailAndRole(email, role)
                 .orElseThrow(() -> new UsernameNotFoundException(ErrorCode.NOT_FOUND_MEMBER.getMessage()));
-    }
-
-    private Authentication getUserAuthentication(LoginRequest request) {
-        try {
-            UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
-                    request.getEmail(), request.getPassword());
-            return authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-        } catch (AuthenticationException e) {
-            throw new MemberException(ErrorCode.UNAUTHORIZED_LOGIN);
-        }
     }
 
     private void validateExistingMember(String email, String nickname) {
@@ -77,6 +70,25 @@ public class MemberService {
     private void validatePassword(String password, String passwordConfirm) {
         if (!password.equals(passwordConfirm)) {
             throw new MemberException(ErrorCode.PASSWORD_MISMATCH);
+        }
+    }
+
+    private Authentication getUserAuthentication(LoginRequest request) {
+        try {
+            UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                    request.getEmail(), request.getPassword());
+            return authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        } catch (AuthenticationException e) {
+            throw new MemberException(ErrorCode.UNAUTHORIZED_LOGIN);
+        }
+    }
+
+    private String determineProfileImageUrl(MultipartFile profileImage) {
+        /* TODO: 프로필 사진 요청이 없는 경우, 기본 프로필 저장 */
+        if (profileImage == null || profileImage.isEmpty()) {
+            return "기본 프로필 이미지 URL";
+        } else {
+            return amazonS3Service.uploadFile(profileImage);
         }
     }
 


### PR DESCRIPTION
## ✨ 관련 이슈

- closed #21 

## ✅ 작업 상세 내용

- [x] **회원 가입 request validation 추가**
  - 회원가입 요청값에 대한 유효성 검증이 실패하는 경우 검증에 실패한 필드들의 에러 메시지를 담아 리스트로 반환하여 클라이언트에게 전달합니다.
  - 비밀번호 일치 검사, 닉네임 중복 검사, 기존 회원 존재 유무 확인 기능을 별도의 메서드로 분리하였습니다.
- [x] **프로필 사진 S3 연동** 
  - 기본 이메일로 회원가입 하는 경우, 프로필 사진을 별도로 입력하지 않은 경우에는 기본 프로필 사진으로 지정합니다. (이 부분은 기본 프로필 이미지 스펙이 정해지면 추가하겠습니다.)
  - 기존에는 회원가입에 성공하면 `Member Entity` 생성 시 `RequestDto`에 담긴`MultipartFile` 형식으로 프로필 사진 데이터를 저장했었는데, AWS S3에 업로드 된 객체 URL을 저장하도록 변경하였습니다. 이는 회원 조회, 수정 로직 구현 시 사용할 예정입니다. 
  - S3 bucket 에는 `/members/{날짜}/{파일명}` 형식으로 객체가 저장되어 추후 관리에 유리하도록 하였습니다.


