### PR TITLE
CustomUserDetail 리팩토링

### DIFF
--- a/src/main/java/com/api/readinglog/common/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/api/readinglog/common/oauth/CustomOAuth2UserService.java
@@ -1,21 +1,27 @@
 package com.api.readinglog.common.oauth;
 
+import com.api.readinglog.common.security.CustomUserDetail;
+import com.api.readinglog.domain.member.entity.Member;
 import com.api.readinglog.domain.member.entity.MemberRole;
+import com.api.readinglog.domain.member.repository.MemberRepository;
 import java.util.Collections;
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final MemberRepository memberRepository;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -30,10 +36,25 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         OAuth2Attribute oAuth2Attribute = OAuth2Attribute.of(registrationId, userNameAttributeName,
                 oAuth2User.getAttributes());
 
+        // 각 플랫폼의 유저 정보를 공통화 처리해주는 부분
         Map<String, Object> memberAttribute = oAuth2Attribute.convertToMap();
 
-        return new DefaultOAuth2User(
+        String email = (String) memberAttribute.get("email");
+        MemberRole memberRole = MemberRole.of(registrationId);
+
+        String name = (String) memberAttribute.get("name");
+        String picture = (String) memberAttribute.get("picture");
+
+        Member member = memberRepository.findByEmailAndRole(email, memberRole)
+                .map(existingMember -> {
+                    existingMember.updateProfile(name, picture);
+                    return existingMember;
+                }).orElseGet(() -> memberRepository.save(Member.of(email, name, picture, memberRole)));
+
+        return new CustomUserDetail(
+                member,
                 Collections.singleton(new SimpleGrantedAuthority(MemberRole.of(registrationId).name())),
-                memberAttribute, "email");
+                memberAttribute);
     }
+
 }

--- a/src/main/java/com/api/readinglog/common/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/com/api/readinglog/common/oauth/OAuthSuccessHandler.java
@@ -2,15 +2,11 @@ package com.api.readinglog.common.oauth;
 
 import com.api.readinglog.common.jwt.JwtToken;
 import com.api.readinglog.common.jwt.JwtTokenProvider;
-import com.api.readinglog.domain.member.entity.Member;
-import com.api.readinglog.domain.member.entity.MemberRole;
-import com.api.readinglog.domain.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -22,27 +18,11 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException {
-
-        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
-
-        String email = oAuth2User.getAttribute("email");
-        String provider = oAuth2User.getAttribute("provider");
-        MemberRole memberRole = MemberRole.of(provider);
-
-        String name = oAuth2User.getAttribute("name");
-        String picture = oAuth2User.getAttribute("picture");
-
-        memberRepository.findByEmailAndRole(email, memberRole)
-                .map(existingMember -> {
-                    existingMember.updateProfile(name, picture);
-                    return existingMember;
-                }).orElseGet(() -> memberRepository.save(Member.of(email, name, picture, memberRole)));
 
         JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);
 

--- a/src/main/java/com/api/readinglog/common/security/CustomUserDetail.java
+++ b/src/main/java/com/api/readinglog/common/security/CustomUserDetail.java
@@ -2,17 +2,37 @@ package com.api.readinglog.common.security;
 
 import com.api.readinglog.domain.member.entity.Member;
 import java.util.Collection;
+import java.util.Map;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 @Getter
-public class CustomUserDetail extends User {
+public class CustomUserDetail extends User implements OAuth2User {
 
-    private final Long id;
+    private final Long id; // 회원 id
+    private Map<String, Object> attributes;
 
+    // 일반 로그인시 사용되는 생성자
     public CustomUserDetail(String username, String password, Long id, Collection<? extends GrantedAuthority> authorities) {
         super(username, password, authorities);
         this.id = id;
+    }
+
+    // OAuth2 인증시 사용되는 생성자
+    public CustomUserDetail(Member member, Collection<? extends GrantedAuthority> authorities, Map<String, Object> attributes) {
+        this(member.getEmail(), member.getPassword(), member.getId(), authorities);
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
     }
 }

--- a/src/main/java/com/api/readinglog/domain/member/entity/Member.java
+++ b/src/main/java/com/api/readinglog/domain/member/entity/Member.java
@@ -57,6 +57,7 @@ public class Member extends BaseTimeEntity {
         return Member.builder()
                 .email(email)
                 .nickname(nickname)
+                .password("") // 소셜 회원은 비밀번호 X
                 .profileImg(profileImg)
                 .role(role)
                 .build();

--- a/src/main/java/com/api/readinglog/domain/member/service/MemberService.java
+++ b/src/main/java/com/api/readinglog/domain/member/service/MemberService.java
@@ -57,6 +57,10 @@ public class MemberService {
                 .orElseThrow(() -> new UsernameNotFoundException(ErrorCode.NOT_FOUND_MEMBER.getMessage()));
     }
 
+    public Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_MEMBER));
+    }
+
     private void validateExistingMember(String email, String nickname) {
         if (memberRepository.findByEmailAndRole(email, MemberRole.MEMBER_NORMAL).isPresent()) {
             throw new MemberException(ErrorCode.MEMBER_ALREADY_EXISTS);


### PR DESCRIPTION
## ✨ 관련 이슈

- closed #30 

## ✅ 작업 상세 내용
- 소셜 인증 객체인 OAuth2User를 CustomUserDetail 타입으로 받기 위해 OAuth2User 인터페이스 구현
- [x] CustomUserDetail에 OAuth2User 인터페이스 구현
- [x] 소셜 유저 회원가입 로직 `CustomOAuth2UserService`로 이동

## 📌 특이사항
- 핸들러에 있던 소셜 회원가입 로직은 CustomOAuth2UserService에서 처리하도록 변경함.

## 📃 참고 레퍼런스
- [Springboot Security와 OAuth2.0을 활용한 소셜로그인](https://velog.io/@kyunghwan1207/22%EB%85%84%EB%8F%84-%ED%95%98%EA%B3%84-%EB%AA%A8%EA%B0%81%EC%BD%94-Springboot-Security%EC%99%80-OAuth2.0%EC%9D%84-%ED%99%9C%EC%9A%A9%ED%95%9C-%EC%86%8C%EC%85%9C%EB%A1%9C%EA%B7%B8%EC%9D%B8%EA%B5%AC%EA%B8%80%EA%B0%9C%EB%B0%9C-4st08oc3)
- [OAuth 2.0 + JWT + Spring Security로 회원 기능 개발하기](https://velog.io/@ch4570/OAuth-2.0-JWT-Spring-Security%EB%A1%9C-%ED%9A%8C%EC%9B%90-%EA%B8%B0%EB%8A%A5-%EA%B0%9C%EB%B0%9C%ED%95%98%EA%B8%B0-%EC%95%B1%EB%93%B1%EB%A1%9D%EA%B3%BC-OAuth-2.0-%EA%B8%B0%EB%8A%A5%EA%B5%AC%ED%98%84)