### PR TITLE
마이페이지 기능 구현

### DIFF
--- a/src/main/java/com/api/readinglog/common/exception/ErrorCode.java
+++ b/src/main/java/com/api/readinglog/common/exception/ErrorCode.java
@@ -24,10 +24,11 @@ public enum ErrorCode {
     // 409
     MEMBER_ALREADY_EXISTS("이미 존재하는 회원입니다.", HttpStatus.CONFLICT),
     NICKNAME_ALREADY_EXISTS("이미 존재하는 닉네임입니다.", HttpStatus.CONFLICT),
-    AWS_S3_FILE_UPLOAD_FAIL("AWS S3 파일 업로드에 실패했습니다.", HttpStatus.CONFLICT),
 
     // 500
-    INTERNAL_SERVER_ERROR("서버 에러 발생!", HttpStatus.INTERNAL_SERVER_ERROR),;
+    INTERNAL_SERVER_ERROR("서버 에러 발생!", HttpStatus.INTERNAL_SERVER_ERROR),
+    AWS_S3_FILE_UPLOAD_FAIL("AWS S3 파일 업로드 실패", HttpStatus.INTERNAL_SERVER_ERROR),
+    AWS_S3_FILE_DELETE_FAIL("AWS S3 파일 삭제 실패", HttpStatus.INTERNAL_SERVER_ERROR),;
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/api/readinglog/common/oauth/OAuth2Attribute.java
+++ b/src/main/java/com/api/readinglog/common/oauth/OAuth2Attribute.java
@@ -20,18 +20,19 @@ public class OAuth2Attribute {
     private String name; // 이름
     private String picture; // 프로필 사진
     private String provider; // 플랫폼
+    private String socialAccessToken;
 
-    static OAuth2Attribute of(String provider, String attributeKey, Map<String, Object> attributes) {
+    static OAuth2Attribute of(String provider, String attributeKey, Map<String, Object> attributes, String socialAccessToken) {
         // 각 플랫폼 별로 제공해주는 데이터가 조금씩 다르기 때문에 분기 처리
         return switch (provider) {
-            case "google" -> google(provider, attributeKey, attributes);
-            case "kakao" -> kakao(provider, attributeKey, attributes);
-            case "naver" -> naver(provider, attributeKey, attributes);
+            case "google" -> google(provider, attributeKey, attributes, socialAccessToken);
+            case "kakao" -> kakao(provider, attributeKey, attributes, socialAccessToken);
+            case "naver" -> naver(provider, attributeKey, attributes, socialAccessToken);
             default -> throw new RuntimeException("지원하는 플랫폼이 아닙니다.");
         };
     }
 
-    private static OAuth2Attribute google(String provider, String attributeKey, Map<String, Object> attributes) {
+    private static OAuth2Attribute google(String provider, String attributeKey, Map<String, Object> attributes, String socialAccessToken) {
         return OAuth2Attribute.builder()
                 .email((String) attributes.get("email"))
                 .name((String) attributes.get("name"))
@@ -39,10 +40,11 @@ public class OAuth2Attribute {
                 .attributes(attributes)
                 .attributeKey(attributeKey)
                 .provider(provider)
+                .socialAccessToken(socialAccessToken)
                 .build();
     }
 
-    private static OAuth2Attribute kakao(String provider, String attributeKey, Map<String, Object> attributes) {
+    private static OAuth2Attribute kakao(String provider, String attributeKey, Map<String, Object> attributes, String socialAccessToken) {
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
 
@@ -53,10 +55,11 @@ public class OAuth2Attribute {
                 .attributes(kakaoAccount)
                 .attributeKey(attributeKey)
                 .provider(provider)
+                .socialAccessToken(socialAccessToken)
                 .build();
     }
 
-    private static OAuth2Attribute naver(String provider, String attributeKey, Map<String, Object> attributes) {
+    private static OAuth2Attribute naver(String provider, String attributeKey, Map<String, Object> attributes, String socialAccessToken) {
         Map<String, Object> response = (Map<String, Object>) attributes.get("response");
 
         return OAuth2Attribute.builder()
@@ -66,6 +69,7 @@ public class OAuth2Attribute {
                 .attributes(response)
                 .attributeKey(attributeKey)
                 .provider(provider)
+                .socialAccessToken(socialAccessToken)
                 .build();
     }
 
@@ -77,6 +81,7 @@ public class OAuth2Attribute {
         map.put("name", name);
         map.put("picture", picture);
         map.put("provider", provider);
+        map.put("socialAccessToken", socialAccessToken);
 
         return map;
     }

--- a/src/main/java/com/api/readinglog/common/oauth/OAuth2RevokeService.java
+++ b/src/main/java/com/api/readinglog/common/oauth/OAuth2RevokeService.java
@@ -1,0 +1,68 @@
+package com.api.readinglog.common.oauth;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2RevokeService {
+
+    @Value("${social.revoke.googleUrl}")
+    private String googleRevokeUrl;
+
+    @Value("${social.revoke.naverUrl}")
+    private String naverRevokeUrl;
+
+    @Value("${social.revoke.kakaoUrl}")
+    private String kakaoRevokeUrl;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
+    private String naverClientId;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+    private String naverClientSecret;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public void revokeKakao(String socialAccessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(socialAccessToken);
+        sendRevokeRequest(kakaoRevokeUrl, new HttpEntity<>(headers));
+    }
+
+    public void revokeNaver(String socialAccessToken) {
+        UriComponents uri = UriComponentsBuilder.fromUriString(naverRevokeUrl)
+                .queryParam("grant_type", "delete")
+                .queryParam("client_id", naverClientId)
+                .queryParam("client_secret", naverClientSecret)
+                .queryParam("access_token", socialAccessToken)
+                .queryParam("service_provider", "naver")
+                .build();
+
+        sendRevokeRequest(uri.toString(), new HttpEntity<>(new HttpHeaders()));
+    }
+
+    public void revokeGoogle(String socialAccessToken) {
+        UriComponents uri = UriComponentsBuilder.fromUriString(googleRevokeUrl)
+                .queryParam("token", socialAccessToken)
+                .build();
+
+        sendRevokeRequest(uri.toString(), new HttpEntity<>(new HttpHeaders()));
+    }
+
+    private void sendRevokeRequest(String url, HttpEntity<Object> httpEntity) {
+        ResponseEntity<String> responseEntity = restTemplate.exchange(url, HttpMethod.POST, httpEntity, String.class);
+        log.info("회원 탈퇴 상태코드: {}", responseEntity.getStatusCode());
+        log.info("회원 탈퇴 결과: {}", responseEntity.getBody());
+    }
+}

--- a/src/main/java/com/api/readinglog/common/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/com/api/readinglog/common/oauth/OAuthSuccessHandler.java
@@ -25,6 +25,7 @@ public class OAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
         JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);
 
+        /* TODO: 로그인 성공 후 발급 한 토큰을 Cookie에 담아서 클라이언트에게 전달 */
         String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080")
                 .queryParam("accessToken", jwtToken.getAccessToken())
                 .queryParam("refreshToken", jwtToken.getRefreshToken())

--- a/src/main/java/com/api/readinglog/domain/member/controller/MemberController.java
+++ b/src/main/java/com/api/readinglog/domain/member/controller/MemberController.java
@@ -64,4 +64,9 @@ public class MemberController {
         return Response.success(HttpStatus.OK, "일반 회원 탈퇴 성공!");
     }
 
+    @DeleteMapping("/social/me")
+    public Response<Void> deleteSocialMember(@AuthenticationPrincipal CustomUserDetail user) {
+        memberService.deleteSocialMember(user.getId());
+        return Response.success(HttpStatus.OK, "소셜 회원 탈퇴 성공!");
+    }
 }

--- a/src/main/java/com/api/readinglog/domain/member/controller/MemberController.java
+++ b/src/main/java/com/api/readinglog/domain/member/controller/MemberController.java
@@ -2,9 +2,12 @@ package com.api.readinglog.domain.member.controller;
 
 import com.api.readinglog.common.jwt.JwtToken;
 import com.api.readinglog.common.response.Response;
-import com.api.readinglog.domain.member.controller.dto.JoinRequest;
-import com.api.readinglog.domain.member.controller.dto.LoginRequest;
-import com.api.readinglog.domain.member.controller.dto.LoginResponse;
+import com.api.readinglog.common.security.CustomUserDetail;
+import com.api.readinglog.domain.member.controller.dto.request.JoinRequest;
+import com.api.readinglog.domain.member.controller.dto.request.LoginRequest;
+import com.api.readinglog.domain.member.controller.dto.response.LoginResponse;
+import com.api.readinglog.domain.member.controller.dto.request.UpdateProfileRequest;
+import com.api.readinglog.domain.member.controller.dto.response.MemberDetailsResponse;
 import com.api.readinglog.domain.member.entity.Member;
 import com.api.readinglog.domain.member.entity.MemberRole;
 import com.api.readinglog.domain.member.service.MemberService;
@@ -13,8 +16,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,11 +46,15 @@ public class MemberController {
     }
 
     @GetMapping("/me")
-    public Response<Member> findMember(Authentication authentication) {
-        String email = authentication.getName();
-        String roleName = authentication.getAuthorities().iterator().next().getAuthority();
-        Member member = memberService.getMemberByEmailAndRole(email, MemberRole.valueOf(roleName));
+    public Response<MemberDetailsResponse> findMember(@AuthenticationPrincipal CustomUserDetail user) {
+        MemberDetailsResponse member = memberService.getMemberDetails(user.getId());
         return Response.success(HttpStatus.OK, "회원 조회 성공!", member);
     }
 
+    @PatchMapping
+    public Response<Void> updateProfile(@AuthenticationPrincipal CustomUserDetail user,
+                                        @ModelAttribute @Valid UpdateProfileRequest request) {
+        memberService.updateProfile(user.getId(), request);
+        return Response.success(HttpStatus.OK, "회원 수정 성공!");
+    }
 }

--- a/src/main/java/com/api/readinglog/domain/member/controller/MemberController.java
+++ b/src/main/java/com/api/readinglog/domain/member/controller/MemberController.java
@@ -3,20 +3,19 @@ package com.api.readinglog.domain.member.controller;
 import com.api.readinglog.common.jwt.JwtToken;
 import com.api.readinglog.common.response.Response;
 import com.api.readinglog.common.security.CustomUserDetail;
+import com.api.readinglog.domain.member.controller.dto.request.DeleteRequest;
 import com.api.readinglog.domain.member.controller.dto.request.JoinRequest;
 import com.api.readinglog.domain.member.controller.dto.request.LoginRequest;
 import com.api.readinglog.domain.member.controller.dto.response.LoginResponse;
 import com.api.readinglog.domain.member.controller.dto.request.UpdateProfileRequest;
 import com.api.readinglog.domain.member.controller.dto.response.MemberDetailsResponse;
-import com.api.readinglog.domain.member.entity.Member;
-import com.api.readinglog.domain.member.entity.MemberRole;
 import com.api.readinglog.domain.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -51,10 +50,18 @@ public class MemberController {
         return Response.success(HttpStatus.OK, "회원 조회 성공!", member);
     }
 
-    @PatchMapping
+    @PatchMapping("/me")
     public Response<Void> updateProfile(@AuthenticationPrincipal CustomUserDetail user,
                                         @ModelAttribute @Valid UpdateProfileRequest request) {
         memberService.updateProfile(user.getId(), request);
         return Response.success(HttpStatus.OK, "회원 수정 성공!");
     }
+
+    @DeleteMapping("/me")
+    public Response<Void> deleteMember(@AuthenticationPrincipal CustomUserDetail user,
+                                       @RequestBody DeleteRequest request) {
+        memberService.deleteMember(user.getId(), request);
+        return Response.success(HttpStatus.OK, "일반 회원 탈퇴 성공!");
+    }
+
 }

--- a/src/main/java/com/api/readinglog/domain/member/controller/dto/request/DeleteRequest.java
+++ b/src/main/java/com/api/readinglog/domain/member/controller/dto/request/DeleteRequest.java
@@ -1,0 +1,12 @@
+package com.api.readinglog.domain.member.controller.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteRequest {
+    private String password;
+}

--- a/src/main/java/com/api/readinglog/domain/member/controller/dto/request/JoinRequest.java
+++ b/src/main/java/com/api/readinglog/domain/member/controller/dto/request/JoinRequest.java
@@ -1,4 +1,4 @@
-package com.api.readinglog.domain.member.controller.dto;
+package com.api.readinglog.domain.member.controller.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/api/readinglog/domain/member/controller/dto/request/LoginRequest.java
+++ b/src/main/java/com/api/readinglog/domain/member/controller/dto/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.api.readinglog.domain.member.controller.dto;
+package com.api.readinglog.domain.member.controller.dto.request;
 
 import lombok.Getter;
 

--- a/src/main/java/com/api/readinglog/domain/member/controller/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/api/readinglog/domain/member/controller/dto/request/UpdateProfileRequest.java
@@ -1,0 +1,20 @@
+package com.api.readinglog.domain.member.controller.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@ToString
+public class UpdateProfileRequest {
+
+    @Size(max = 8, message = "닉네임은 8자 이하로 입력해야 합니다.")
+    @Pattern(regexp = "^[\\p{L}0-9]+$", message = "닉네임에는 특수 문자를 사용할 수 없습니다.")
+    private String nickname;
+
+    private MultipartFile profileImg;
+}

--- a/src/main/java/com/api/readinglog/domain/member/controller/dto/response/LoginResponse.java
+++ b/src/main/java/com/api/readinglog/domain/member/controller/dto/response/LoginResponse.java
@@ -1,4 +1,4 @@
-package com.api.readinglog.domain.member.controller.dto;
+package com.api.readinglog.domain.member.controller.dto.response;
 
 import com.api.readinglog.common.jwt.JwtToken;
 import lombok.Builder;

--- a/src/main/java/com/api/readinglog/domain/member/controller/dto/response/MemberDetailsResponse.java
+++ b/src/main/java/com/api/readinglog/domain/member/controller/dto/response/MemberDetailsResponse.java
@@ -1,0 +1,43 @@
+package com.api.readinglog.domain.member.controller.dto.response;
+
+import com.api.readinglog.domain.member.entity.Member;
+import com.api.readinglog.domain.member.entity.MemberRole;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberDetailsResponse {
+
+    private Long id;
+    private String email;
+    private String nickname;
+    private String password;
+    private String profileImg;
+    private MemberRole role;
+    private LocalDateTime createdAt;
+
+    @Builder
+    private MemberDetailsResponse(Long id, String email, String nickname, String password, String profileImg,
+                                 MemberRole role, LocalDateTime createdAt) {
+        this.id = id;
+        this.email = email;
+        this.nickname = nickname;
+        this.password = password;
+        this.profileImg = profileImg;
+        this.role = role;
+        this.createdAt = createdAt;
+    }
+
+    public static MemberDetailsResponse of(Member member, String profileImgUrl) {
+        return MemberDetailsResponse.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .password(member.getPassword())
+                .profileImg(profileImgUrl)
+                .role(member.getRole())
+                .createdAt(member.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/api/readinglog/domain/member/entity/Member.java
+++ b/src/main/java/com/api/readinglog/domain/member/entity/Member.java
@@ -1,7 +1,7 @@
 package com.api.readinglog.domain.member.entity;
 
 import com.api.readinglog.common.base.BaseTimeEntity;
-import com.api.readinglog.domain.member.controller.dto.JoinRequest;
+import com.api.readinglog.domain.member.controller.dto.request.JoinRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/api/readinglog/domain/member/service/MemberService.java
+++ b/src/main/java/com/api/readinglog/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.api.readinglog.common.exception.ErrorCode;
 import com.api.readinglog.common.exception.custom.MemberException;
 import com.api.readinglog.common.jwt.JwtToken;
 import com.api.readinglog.common.jwt.JwtTokenProvider;
+import com.api.readinglog.common.oauth.OAuth2RevokeService;
 import com.api.readinglog.domain.member.controller.dto.request.DeleteRequest;
 import com.api.readinglog.domain.member.controller.dto.request.JoinRequest;
 import com.api.readinglog.domain.member.controller.dto.request.LoginRequest;
@@ -12,6 +13,7 @@ import com.api.readinglog.domain.member.controller.dto.request.UpdateProfileRequ
 import com.api.readinglog.domain.member.controller.dto.response.MemberDetailsResponse;
 import com.api.readinglog.domain.member.entity.Member;
 import com.api.readinglog.domain.member.entity.MemberRole;
+import com.api.readinglog.domain.token.repository.AccessTokenRepository;
 import com.api.readinglog.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,10 +34,12 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final AccessTokenRepository accessTokenRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final AmazonS3Service amazonS3Service;
+    private final OAuth2RevokeService oAuth2RevokeService;
 
     public void join(JoinRequest request) {
         validateExistingMember(request.getEmail(), request.getNickname());
@@ -69,7 +73,7 @@ public class MemberService {
         String profileImg = member.getProfileImg();
 
         // 소셜 로그인 한 회원이 아닌 경우에만 S3에서 이미지 객체 URL을 가져옴
-        if(member.getRole().equals(MemberRole.MEMBER_NORMAL)) {
+        if (member.getRole().equals(MemberRole.MEMBER_NORMAL)) {
             profileImg = amazonS3Service.getFileUrl(member.getProfileImg());
         }
         return MemberDetailsResponse.of(member, profileImg);
@@ -81,7 +85,7 @@ public class MemberService {
         // 기존 이미지를 기본 값으로 설정
         String updatedFileName = member.getProfileImg();
 
-        if(!isEmptyProfileImg(request.getProfileImg())) {
+        if (!isEmptyProfileImg(request.getProfileImg())) {
             // 수정할 이미지 데이터가 존재할 경우, 기존 이미지 삭제 후 새 이미지 업로드
             amazonS3Service.deleteFile(member.getProfileImg());
             updatedFileName = amazonS3Service.uploadFile(request.getProfileImg());
@@ -91,10 +95,31 @@ public class MemberService {
 
     public void deleteMember(Long memberId, DeleteRequest request) {
         Member member = getMemberById(memberId);
-        if(!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
+        if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
             throw new MemberException(ErrorCode.PASSWORD_MISMATCH);
         }
         memberRepository.deleteById(memberId);
+    }
+
+    public void deleteSocialMember(Long memberId) {
+        Member member = getMemberById(memberId);
+
+        accessTokenRepository.findByMember(member).ifPresent(accessToken -> {
+            String socialAccessToken = accessToken.getSocialAccessToken();
+            revokeSocialAccessToken(member, socialAccessToken);
+            accessTokenRepository.delete(accessToken); // AccessToken 삭제
+        });
+
+        memberRepository.deleteById(member.getId()); // 회원 정보 삭제
+    }
+
+    // 소셜 계정 연동 해제 처리를 별도의 메서드로 추출
+    private void revokeSocialAccessToken(Member member, String socialAccessToken) {
+        switch (member.getRole()) {
+            case MEMBER_KAKAO -> oAuth2RevokeService.revokeKakao(socialAccessToken);
+            case MEMBER_GOOGLE -> oAuth2RevokeService.revokeGoogle(socialAccessToken);
+            case MEMBER_NAVER -> oAuth2RevokeService.revokeNaver(socialAccessToken);
+        }
     }
 
     private void validateExistingMember(String email, String nickname) {

--- a/src/main/java/com/api/readinglog/domain/member/service/MemberService.java
+++ b/src/main/java/com/api/readinglog/domain/member/service/MemberService.java
@@ -63,6 +63,17 @@ public class MemberService {
         return memberRepository.findById(memberId).orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_MEMBER));
     }
 
+    public MemberDetailsResponse getMemberDetails(Long memberId) {
+        Member member = getMemberById(memberId);
+        String profileImg = member.getProfileImg();
+
+        // 소셜 로그인 한 회원이 아닌 경우에만 S3에서 이미지 객체 URL을 가져옴
+        if(member.getRole().equals(MemberRole.MEMBER_NORMAL)) {
+            profileImg = amazonS3Service.getFileUrl(member.getProfileImg());
+        }
+        return MemberDetailsResponse.of(member, profileImg);
+    }
+
     public void updateProfile(Long memberId, UpdateProfileRequest request) {
         Member member = getMemberById(memberId);
 

--- a/src/main/java/com/api/readinglog/domain/member/service/MemberService.java
+++ b/src/main/java/com/api/readinglog/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.api.readinglog.common.exception.ErrorCode;
 import com.api.readinglog.common.exception.custom.MemberException;
 import com.api.readinglog.common.jwt.JwtToken;
 import com.api.readinglog.common.jwt.JwtTokenProvider;
+import com.api.readinglog.domain.member.controller.dto.request.DeleteRequest;
 import com.api.readinglog.domain.member.controller.dto.request.JoinRequest;
 import com.api.readinglog.domain.member.controller.dto.request.LoginRequest;
 import com.api.readinglog.domain.member.controller.dto.request.UpdateProfileRequest;
@@ -86,6 +87,14 @@ public class MemberService {
             updatedFileName = amazonS3Service.uploadFile(request.getProfileImg());
         }
         member.updateProfile(request.getNickname(), updatedFileName);
+    }
+
+    public void deleteMember(Long memberId, DeleteRequest request) {
+        Member member = getMemberById(memberId);
+        if(!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
+            throw new MemberException(ErrorCode.PASSWORD_MISMATCH);
+        }
+        memberRepository.deleteById(memberId);
     }
 
     private void validateExistingMember(String email, String nickname) {

--- a/src/main/java/com/api/readinglog/domain/token/entity/AccessToken.java
+++ b/src/main/java/com/api/readinglog/domain/token/entity/AccessToken.java
@@ -1,0 +1,47 @@
+package com.api.readinglog.domain.token.entity;
+
+import com.api.readinglog.domain.member.entity.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AccessToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String socialAccessToken;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public AccessToken(String socialAccessToken, Member member) {
+        this.socialAccessToken = socialAccessToken;
+        this.member = member;
+    }
+
+    public static AccessToken of(String socialAccessToken, Member member) {
+        return AccessToken.builder()
+                .socialAccessToken(socialAccessToken)
+                .member(member)
+                .build();
+    }
+
+    public void updateSocialAccessToken(String socialAccessToken) {
+        this.socialAccessToken = socialAccessToken;
+    }
+}

--- a/src/main/java/com/api/readinglog/domain/token/repository/AccessTokenRepository.java
+++ b/src/main/java/com/api/readinglog/domain/token/repository/AccessTokenRepository.java
@@ -1,0 +1,10 @@
+package com.api.readinglog.domain.token.repository;
+
+import com.api.readinglog.domain.token.entity.AccessToken;
+import com.api.readinglog.domain.member.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccessTokenRepository extends JpaRepository<AccessToken, Long> {
+    Optional<AccessToken> findByMember(Member member);
+}


### PR DESCRIPTION
## ✨ 관련 이슈

- closed #35 

## ✅ 작업 상세 내용

- [x] 회원 상세 조회 기능 구현 
  - 이미지 파일 URL 조회 가능
- [x] 회원 수정 기능 구현 
  - AWS S3 이미지 삭제 기능
  - 프로필 사진 업데이트 기능
  - 닉네임 업데이트 기능
- [x] 회원 탈퇴 기능 구현
  - 일반 회원 탈퇴
  - 소셜 회원 탈퇴

## 📌 특이사항
- 소셜 플랫폼 연동 해제를 위해서는 소셜 액세스 토큰이 필요했습니다. 이때 소셜 로그인 성공 시 userDetails 내에 액세스 토큰을 저장하고, 꺼내서 쓰는 방식을 계획했었습니다.
- 하지만 토큰을 저장하는 과정에서는 보안 문제와 효율성을 고려하여, 암호화된 형태로 DB 저장하도록 계획을 수정했습니다. 
- AccessToken Table을 생성하여 Member와 1:1 연관관계를 설정하였습니다. 
- **`TODO`** : 액세스 토큰 만료 검사, 테스트 코드 작성

## 📃 참고 레퍼런스

- [소셜 회원 탈퇴 기능 구현](https://velog.io/@ncookie/IMAD-%EC%86%8C%EC%85%9C%ED%9A%8C%EC%9B%90-%ED%83%88%ED%87%B4-%EA%B8%B0%EB%8A%A5-%EA%B5%AC%ED%98%84)
- [카카오 공식 문서](https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api)
- [네이버 공식 문서](https://developers.naver.com/docs/login/devguide/devguide.md#5-3-%EB%84%A4%EC%9D%B4%EB%B2%84-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EC%97%B0%EB%8F%99-%ED%95%B4%EC%A0%9C)
