### PR TITLE
한 줄 리뷰 API 구현

### DIFF
--- a/src/main/java/com/api/readinglog/common/exception/ErrorCode.java
+++ b/src/main/java/com/api/readinglog/common/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     NOT_FOUND_BOOK("등록된 책이 존재하지 않습니다!", HttpStatus.NOT_FOUND),
     NOT_FOUND_HIGHLIGHT("등록된 책이 존재하지 않습니다!", HttpStatus.NOT_FOUND),
     NOT_FOUND_SUMMARY("등록된 한줄평이 존재하지 않습니다!", HttpStatus.NOT_FOUND),
+    NOT_FOUND_FEED("피드 목록이 존재하지 않습니다!", HttpStatus.NOT_FOUND),
 
     // 409
     MEMBER_ALREADY_EXISTS("이미 존재하는 회원입니다.", HttpStatus.CONFLICT),

--- a/src/main/java/com/api/readinglog/common/exception/ErrorCode.java
+++ b/src/main/java/com/api/readinglog/common/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     NOT_FOUND_SEARCH("검색 결과가 존재하지 않습니다!", HttpStatus.NOT_FOUND),
     NOT_FOUND_BOOK("등록된 책이 존재하지 않습니다!", HttpStatus.NOT_FOUND),
     NOT_FOUND_HIGHLIGHT("등록된 책이 존재하지 않습니다!", HttpStatus.NOT_FOUND),
+    NOT_FOUND_SUMMARY("등록된 한줄평이 존재하지 않습니다!", HttpStatus.NOT_FOUND),
 
     // 409
     MEMBER_ALREADY_EXISTS("이미 존재하는 회원입니다.", HttpStatus.CONFLICT),

--- a/src/main/java/com/api/readinglog/common/exception/ErrorCode.java
+++ b/src/main/java/com/api/readinglog/common/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     // 409
     MEMBER_ALREADY_EXISTS("이미 존재하는 회원입니다.", HttpStatus.CONFLICT),
     NICKNAME_ALREADY_EXISTS("이미 존재하는 닉네임입니다.", HttpStatus.CONFLICT),
+    SUMMARY_ALREADY_EXISTS("한줄평이 이미 존재합니다.", HttpStatus.CONFLICT),
 
     // 500
     INTERNAL_SERVER_ERROR("서버 에러 발생!", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/api/readinglog/common/exception/custom/SummaryException.java
+++ b/src/main/java/com/api/readinglog/common/exception/custom/SummaryException.java
@@ -1,0 +1,10 @@
+package com.api.readinglog.common.exception.custom;
+
+import com.api.readinglog.common.exception.CustomException;
+import com.api.readinglog.common.exception.ErrorCode;
+
+public class SummaryException extends CustomException {
+    public SummaryException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/api/readinglog/domain/hightlight/controller/HighlightController.java
+++ b/src/main/java/com/api/readinglog/domain/hightlight/controller/HighlightController.java
@@ -38,8 +38,8 @@ public class HighlightController {
                                                         @PathVariable Long bookId,
                                                         @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
 
-        Page<HighlightResponse> highlights = highlightService.highlights(user.getId(), bookId, pageable);
-        return Response.success(HttpStatus.OK, "하이라이트 목록 조회 성공", highlights);
+        Page<HighlightResponse> response = highlightService.highlights(user.getId(), bookId, pageable);
+        return Response.success(HttpStatus.OK, "하이라이트 목록 조회 성공", response);
     }
 
     @PostMapping("/{bookId}")

--- a/src/main/java/com/api/readinglog/domain/hightlight/service/HighlightService.java
+++ b/src/main/java/com/api/readinglog/domain/hightlight/service/HighlightService.java
@@ -26,6 +26,7 @@ public class HighlightService {
     private final MemberService memberService;
     private final BookService bookService;
 
+    @Transactional(readOnly = true)
     public Page<HighlightResponse> highlights(Long memberId, Long bookId, Pageable pageable) {
         Member member = memberService.getMemberById(memberId);
         Book book = bookService.getBookById(bookId);

--- a/src/main/java/com/api/readinglog/domain/summary/controller/SummaryController.java
+++ b/src/main/java/com/api/readinglog/domain/summary/controller/SummaryController.java
@@ -4,12 +4,14 @@ import com.api.readinglog.common.response.Response;
 import com.api.readinglog.common.security.CustomUserDetail;
 import com.api.readinglog.domain.summary.controller.dto.request.ModifyRequest;
 import com.api.readinglog.domain.summary.controller.dto.request.WriteRequest;
+import com.api.readinglog.domain.summary.controller.dto.response.SummaryResponse;
 import com.api.readinglog.domain.summary.service.SummaryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,6 +25,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class SummaryController {
 
     private final SummaryService summaryService;
+
+    @GetMapping("/{bookId}/me")
+    public Response<SummaryResponse> mySummary(@AuthenticationPrincipal CustomUserDetail user, @PathVariable Long bookId) {
+
+        SummaryResponse response = summaryService.mySummary(user.getId(), bookId);
+        return Response.success(HttpStatus.OK, "내 한줄평 조회 성공", response);
+    }
 
     @PostMapping("/{bookId}")
     public Response<Void> write(@AuthenticationPrincipal CustomUserDetail user,

--- a/src/main/java/com/api/readinglog/domain/summary/controller/SummaryController.java
+++ b/src/main/java/com/api/readinglog/domain/summary/controller/SummaryController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,6 +40,13 @@ public class SummaryController {
 
         summaryService.modify(user.getId(), summaryId, writeRequest);
         return Response.success(HttpStatus.OK, "한줄평 수정 성공");
+    }
+
+    @DeleteMapping("/{summaryId}")
+    public Response<Void> delete(@AuthenticationPrincipal CustomUserDetail user, @PathVariable Long summaryId) {
+
+        summaryService.delete(user.getId(), summaryId);
+        return Response.success(HttpStatus.OK, "한줄평 삭제 성공");
     }
 
 }

--- a/src/main/java/com/api/readinglog/domain/summary/controller/SummaryController.java
+++ b/src/main/java/com/api/readinglog/domain/summary/controller/SummaryController.java
@@ -2,12 +2,14 @@ package com.api.readinglog.domain.summary.controller;
 
 import com.api.readinglog.common.response.Response;
 import com.api.readinglog.common.security.CustomUserDetail;
+import com.api.readinglog.domain.summary.controller.dto.request.ModifyRequest;
 import com.api.readinglog.domain.summary.controller.dto.request.WriteRequest;
 import com.api.readinglog.domain.summary.service.SummaryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,6 +30,15 @@ public class SummaryController {
 
         summaryService.write(user.getId(), bookId, writeRequest);
         return Response.success(HttpStatus.CREATED, "한줄평 작성 성공");
+    }
+
+    @PatchMapping("/{summaryId}")
+    public Response<Void> modify(@AuthenticationPrincipal CustomUserDetail user,
+                                 @PathVariable Long summaryId,
+                                 @RequestBody @Valid ModifyRequest writeRequest) {
+
+        summaryService.modify(user.getId(), summaryId, writeRequest);
+        return Response.success(HttpStatus.OK, "한줄평 수정 성공");
     }
 
 }

--- a/src/main/java/com/api/readinglog/domain/summary/controller/SummaryController.java
+++ b/src/main/java/com/api/readinglog/domain/summary/controller/SummaryController.java
@@ -1,0 +1,33 @@
+package com.api.readinglog.domain.summary.controller;
+
+import com.api.readinglog.common.response.Response;
+import com.api.readinglog.common.security.CustomUserDetail;
+import com.api.readinglog.domain.summary.controller.dto.request.WriteRequest;
+import com.api.readinglog.domain.summary.service.SummaryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/summaries")
+@RequiredArgsConstructor
+public class SummaryController {
+
+    private final SummaryService summaryService;
+
+    @PostMapping("/{bookId}")
+    public Response<Void> write(@AuthenticationPrincipal CustomUserDetail user,
+                                @PathVariable Long bookId,
+                                @RequestBody @Valid WriteRequest writeRequest) {
+
+        summaryService.write(user.getId(), bookId, writeRequest);
+        return Response.success(HttpStatus.CREATED, "한줄평 작성 성공");
+    }
+
+}

--- a/src/main/java/com/api/readinglog/domain/summary/controller/SummaryController.java
+++ b/src/main/java/com/api/readinglog/domain/summary/controller/SummaryController.java
@@ -5,9 +5,14 @@ import com.api.readinglog.common.security.CustomUserDetail;
 import com.api.readinglog.domain.summary.controller.dto.request.ModifyRequest;
 import com.api.readinglog.domain.summary.controller.dto.request.WriteRequest;
 import com.api.readinglog.domain.summary.controller.dto.response.SummaryResponse;
+import com.api.readinglog.domain.summary.controller.dto.response.MySummaryResponse;
 import com.api.readinglog.domain.summary.service.SummaryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -26,10 +31,17 @@ public class SummaryController {
 
     private final SummaryService summaryService;
 
-    @GetMapping("/{bookId}/me")
-    public Response<SummaryResponse> mySummary(@AuthenticationPrincipal CustomUserDetail user, @PathVariable Long bookId) {
+    @GetMapping("/feed")
+    public Response<Page<SummaryResponse>> feed(@PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+        // TODO: querydsl 동적 쿼리 처리
+        return Response.success(HttpStatus.OK, "피드 목록 조회 성공", summaryService.feed(pageable));
+    }
 
-        SummaryResponse response = summaryService.mySummary(user.getId(), bookId);
+    @GetMapping("/{bookId}/me")
+    public Response<MySummaryResponse> mySummary(@AuthenticationPrincipal CustomUserDetail user,
+                                                 @PathVariable Long bookId) {
+
+        MySummaryResponse response = summaryService.mySummary(user.getId(), bookId);
         return Response.success(HttpStatus.OK, "내 한줄평 조회 성공", response);
     }
 

--- a/src/main/java/com/api/readinglog/domain/summary/controller/dto/request/ModifyRequest.java
+++ b/src/main/java/com/api/readinglog/domain/summary/controller/dto/request/ModifyRequest.java
@@ -1,0 +1,14 @@
+package com.api.readinglog.domain.summary.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+public class ModifyRequest {
+
+    @NotBlank(message = "본문 내용은 필수 입력값 입니다.")
+    @Length(max = 500, message = "한줄평은 100자 이내로 작성해주세요.")
+    private String content;
+}

--- a/src/main/java/com/api/readinglog/domain/summary/controller/dto/request/WriteRequest.java
+++ b/src/main/java/com/api/readinglog/domain/summary/controller/dto/request/WriteRequest.java
@@ -1,0 +1,18 @@
+package com.api.readinglog.domain.summary.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+public class WriteRequest {
+
+    @NotBlank(message = "본문 내용은 필수 입력값 입니다.")
+    @Length(max = 100, message = "한줄평은 100자 이내로 작성해주세요.")
+    private String content;
+
+}
+
+
+

--- a/src/main/java/com/api/readinglog/domain/summary/controller/dto/response/MySummaryResponse.java
+++ b/src/main/java/com/api/readinglog/domain/summary/controller/dto/response/MySummaryResponse.java
@@ -1,0 +1,23 @@
+package com.api.readinglog.domain.summary.controller.dto.response;
+
+import com.api.readinglog.domain.summary.entity.Summary;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MySummaryResponse {
+
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static MySummaryResponse fromEntity(Summary summary) {
+        return MySummaryResponse.builder()
+                .content(summary.getContent())
+                .createdAt(summary.getCreatedAt())
+                .modifiedAt(summary.getModifiedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/api/readinglog/domain/summary/controller/dto/response/SummaryResponse.java
+++ b/src/main/java/com/api/readinglog/domain/summary/controller/dto/response/SummaryResponse.java
@@ -9,15 +9,23 @@ import lombok.Getter;
 @Builder
 public class SummaryResponse {
 
+    private String nickname;
+    private String bookTitle;
+    private String bookAuthor;
+    private String bookCover;
     private String content;
     private LocalDateTime createdAt;
-    private LocalDateTime modifiedAt;
+    // TODO: 좋아요 개수
+
 
     public static SummaryResponse fromEntity(Summary summary) {
         return SummaryResponse.builder()
+                .nickname(summary.getMember().getNickname())
+                .bookTitle(summary.getBook().getTitle())
+                .bookAuthor(summary.getBook().getAuthor())
+                .bookCover(summary.getBook().getCover())
                 .content(summary.getContent())
                 .createdAt(summary.getCreatedAt())
-                .modifiedAt(summary.getModifiedAt())
                 .build();
     }
 }

--- a/src/main/java/com/api/readinglog/domain/summary/controller/dto/response/SummaryResponse.java
+++ b/src/main/java/com/api/readinglog/domain/summary/controller/dto/response/SummaryResponse.java
@@ -1,0 +1,23 @@
+package com.api.readinglog.domain.summary.controller.dto.response;
+
+import com.api.readinglog.domain.summary.entity.Summary;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SummaryResponse {
+
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static SummaryResponse fromEntity(Summary summary) {
+        return SummaryResponse.builder()
+                .content(summary.getContent())
+                .createdAt(summary.getCreatedAt())
+                .modifiedAt(summary.getModifiedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/api/readinglog/domain/summary/entity/Summary.java
+++ b/src/main/java/com/api/readinglog/domain/summary/entity/Summary.java
@@ -1,0 +1,58 @@
+package com.api.readinglog.domain.summary.entity;
+
+import com.api.readinglog.common.base.BaseTimeEntity;
+import com.api.readinglog.domain.book.entity.Book;
+import com.api.readinglog.domain.member.entity.Member;
+import com.api.readinglog.domain.summary.controller.dto.request.WriteRequest;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE summary SET deleted_at = NOW() WHERE summary_id = ?")
+@Where(clause = "deleted_at IS NULL")
+public class Summary extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "summary_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @Column(name = "summary_content", nullable = false, length = 100)
+    private String content;
+
+    @Builder
+    private Summary(Member member, Book book, String content) {
+        this.member = member;
+        this.book = book;
+        this.content = content;
+    }
+
+    public static Summary of(Member member, Book book, WriteRequest request) {
+        return Summary.builder()
+                .member(member)
+                .book(book)
+                .content(request.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/api/readinglog/domain/summary/entity/Summary.java
+++ b/src/main/java/com/api/readinglog/domain/summary/entity/Summary.java
@@ -3,6 +3,7 @@ package com.api.readinglog.domain.summary.entity;
 import com.api.readinglog.common.base.BaseTimeEntity;
 import com.api.readinglog.domain.book.entity.Book;
 import com.api.readinglog.domain.member.entity.Member;
+import com.api.readinglog.domain.summary.controller.dto.request.ModifyRequest;
 import com.api.readinglog.domain.summary.controller.dto.request.WriteRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -54,5 +55,9 @@ public class Summary extends BaseTimeEntity {
                 .book(book)
                 .content(request.getContent())
                 .build();
+    }
+
+    public void modify(ModifyRequest request) {
+        this.content = request.getContent();
     }
 }

--- a/src/main/java/com/api/readinglog/domain/summary/repository/SummaryRepository.java
+++ b/src/main/java/com/api/readinglog/domain/summary/repository/SummaryRepository.java
@@ -9,4 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface SummaryRepository extends JpaRepository<Summary, Long> {
 
     Optional<Summary> findByMemberAndBook(Member member, Book book);
+
 }

--- a/src/main/java/com/api/readinglog/domain/summary/repository/SummaryRepository.java
+++ b/src/main/java/com/api/readinglog/domain/summary/repository/SummaryRepository.java
@@ -1,0 +1,12 @@
+package com.api.readinglog.domain.summary.repository;
+
+import com.api.readinglog.domain.book.entity.Book;
+import com.api.readinglog.domain.member.entity.Member;
+import com.api.readinglog.domain.summary.entity.Summary;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SummaryRepository extends JpaRepository<Summary, Long> {
+
+    Optional<Summary> findByMemberAndBook(Member member, Book book);
+}

--- a/src/main/java/com/api/readinglog/domain/summary/repository/SummaryRepository.java
+++ b/src/main/java/com/api/readinglog/domain/summary/repository/SummaryRepository.java
@@ -4,10 +4,14 @@ import com.api.readinglog.domain.book.entity.Book;
 import com.api.readinglog.domain.member.entity.Member;
 import com.api.readinglog.domain.summary.entity.Summary;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SummaryRepository extends JpaRepository<Summary, Long> {
 
     Optional<Summary> findByMemberAndBook(Member member, Book book);
+
+    Page<Summary> findAllBy(Pageable pageable);
 
 }

--- a/src/main/java/com/api/readinglog/domain/summary/service/SummaryService.java
+++ b/src/main/java/com/api/readinglog/domain/summary/service/SummaryService.java
@@ -6,6 +6,7 @@ import com.api.readinglog.domain.book.entity.Book;
 import com.api.readinglog.domain.book.service.BookService;
 import com.api.readinglog.domain.member.entity.Member;
 import com.api.readinglog.domain.member.service.MemberService;
+import com.api.readinglog.domain.summary.controller.dto.request.ModifyRequest;
 import com.api.readinglog.domain.summary.controller.dto.request.WriteRequest;
 import com.api.readinglog.domain.summary.entity.Summary;
 import com.api.readinglog.domain.summary.repository.SummaryRepository;
@@ -33,5 +34,21 @@ public class SummaryService {
 
         Summary summary = Summary.of(member, book, request);
         summaryRepository.save(summary);
+    }
+
+    public void modify(Long memberId, Long summaryId, ModifyRequest request) {
+        Member member = memberService.getMemberById(memberId);
+        Summary summary = getSummaryById(summaryId);
+
+        if (summary.getMember() != member) {
+            throw new SummaryException(ErrorCode.FORBIDDEN_MODIFY);
+        }
+
+        summary.modify(request);
+    }
+
+    public Summary getSummaryById(Long summaryId) {
+        return summaryRepository.findById(summaryId)
+                .orElseThrow(() -> new SummaryException(ErrorCode.NOT_FOUND_SUMMARY));
     }
 }

--- a/src/main/java/com/api/readinglog/domain/summary/service/SummaryService.java
+++ b/src/main/java/com/api/readinglog/domain/summary/service/SummaryService.java
@@ -1,0 +1,37 @@
+package com.api.readinglog.domain.summary.service;
+
+import com.api.readinglog.common.exception.ErrorCode;
+import com.api.readinglog.common.exception.custom.SummaryException;
+import com.api.readinglog.domain.book.entity.Book;
+import com.api.readinglog.domain.book.service.BookService;
+import com.api.readinglog.domain.member.entity.Member;
+import com.api.readinglog.domain.member.service.MemberService;
+import com.api.readinglog.domain.summary.controller.dto.request.WriteRequest;
+import com.api.readinglog.domain.summary.entity.Summary;
+import com.api.readinglog.domain.summary.repository.SummaryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SummaryService {
+
+    private final SummaryRepository summaryRepository;
+    private final MemberService memberService;
+    private final BookService bookService;
+
+    public void write(Long memberId, Long bookId, WriteRequest request) {
+        Member member = memberService.getMemberById(memberId);
+        Book book = bookService.getBookById(bookId);
+
+        // 해당 책에 대한 한줄평이 존재하는 경우 exception
+        summaryRepository.findByMemberAndBook(member, book).ifPresent(it -> {
+            throw new SummaryException(ErrorCode.SUMMARY_ALREADY_EXISTS);
+        });
+
+        Summary summary = Summary.of(member, book, request);
+        summaryRepository.save(summary);
+    }
+}

--- a/src/main/java/com/api/readinglog/domain/summary/service/SummaryService.java
+++ b/src/main/java/com/api/readinglog/domain/summary/service/SummaryService.java
@@ -47,6 +47,17 @@ public class SummaryService {
         summary.modify(request);
     }
 
+    public void delete(Long memberId, Long summaryId) {
+        Member member = memberService.getMemberById(memberId);
+        Summary summary = getSummaryById(summaryId);
+
+        if (summary.getMember() != member) {
+            throw new SummaryException(ErrorCode.FORBIDDEN_DELETE);
+        }
+
+        summaryRepository.delete(summary);
+    }
+
     public Summary getSummaryById(Long summaryId) {
         return summaryRepository.findById(summaryId)
                 .orElseThrow(() -> new SummaryException(ErrorCode.NOT_FOUND_SUMMARY));

--- a/src/main/java/com/api/readinglog/domain/summary/service/SummaryService.java
+++ b/src/main/java/com/api/readinglog/domain/summary/service/SummaryService.java
@@ -8,6 +8,7 @@ import com.api.readinglog.domain.member.entity.Member;
 import com.api.readinglog.domain.member.service.MemberService;
 import com.api.readinglog.domain.summary.controller.dto.request.ModifyRequest;
 import com.api.readinglog.domain.summary.controller.dto.request.WriteRequest;
+import com.api.readinglog.domain.summary.controller.dto.response.SummaryResponse;
 import com.api.readinglog.domain.summary.entity.Summary;
 import com.api.readinglog.domain.summary.repository.SummaryRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,18 @@ public class SummaryService {
     private final SummaryRepository summaryRepository;
     private final MemberService memberService;
     private final BookService bookService;
+
+    @Transactional(readOnly = true)
+    public SummaryResponse mySummary(Long memberId, Long bookId) {
+        Member member = memberService.getMemberById(memberId);
+        Book book = bookService.getBookById(bookId);
+
+        // 해당 책에 대한 한줄평이 존재하면 반환
+        Summary summary = summaryRepository.findByMemberAndBook(member, book)
+                .orElseThrow(() -> new SummaryException(ErrorCode.NOT_FOUND_SUMMARY));
+
+        return SummaryResponse.fromEntity(summary);
+    }
 
     public void write(Long memberId, Long bookId, WriteRequest request) {
         Member member = memberService.getMemberById(memberId);

--- a/src/main/java/com/api/readinglog/domain/summary/service/SummaryService.java
+++ b/src/main/java/com/api/readinglog/domain/summary/service/SummaryService.java
@@ -9,9 +9,12 @@ import com.api.readinglog.domain.member.service.MemberService;
 import com.api.readinglog.domain.summary.controller.dto.request.ModifyRequest;
 import com.api.readinglog.domain.summary.controller.dto.request.WriteRequest;
 import com.api.readinglog.domain.summary.controller.dto.response.SummaryResponse;
+import com.api.readinglog.domain.summary.controller.dto.response.MySummaryResponse;
 import com.api.readinglog.domain.summary.entity.Summary;
 import com.api.readinglog.domain.summary.repository.SummaryRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,7 +28,19 @@ public class SummaryService {
     private final BookService bookService;
 
     @Transactional(readOnly = true)
-    public SummaryResponse mySummary(Long memberId, Long bookId) {
+    public Page<SummaryResponse> feed(Pageable pageable) {
+        Page<SummaryResponse> feed = summaryRepository.findAllBy(pageable).map(SummaryResponse::fromEntity);
+
+        // 피드가 존재하지 않는 경우 예외 처리
+        if (feed.getContent().isEmpty()) {
+            throw new SummaryException(ErrorCode.NOT_FOUND_FEED);
+        }
+
+        return feed;
+    }
+
+    @Transactional(readOnly = true)
+    public MySummaryResponse mySummary(Long memberId, Long bookId) {
         Member member = memberService.getMemberById(memberId);
         Book book = bookService.getBookById(bookId);
 
@@ -33,7 +48,7 @@ public class SummaryService {
         Summary summary = summaryRepository.findByMemberAndBook(member, book)
                 .orElseThrow(() -> new SummaryException(ErrorCode.NOT_FOUND_SUMMARY));
 
-        return SummaryResponse.fromEntity(summary);
+        return MySummaryResponse.fromEntity(summary);
     }
 
     public void write(Long memberId, Long bookId, WriteRequest request) {
@@ -75,4 +90,5 @@ public class SummaryService {
         return summaryRepository.findById(summaryId)
                 .orElseThrow(() -> new SummaryException(ErrorCode.NOT_FOUND_SUMMARY));
     }
+
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- closed #54 

## ✅ 작업 상세 내용
- [x] 한 줄 리뷰 작성
- [x] 한 줄 리뷰 수정
- [x] 한 줄 리뷰 삭제
- [x] 내가 쓴 한 줄 리뷰 조회
- [x] 피드 목록 조회

## 📌 특이사항
- 피드 목록 필터링 및 정렬 기능은 `querydsl`을 사용해서 처리할 예정
- 회원 조회시 항상 1번 회원이 나오는 에러 발견
