### PR TITLE
북로그 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/api/readinglog/common/cache/CacheInitializer.java
+++ b/src/main/java/com/api/readinglog/common/cache/CacheInitializer.java
@@ -1,0 +1,32 @@
+package com.api.readinglog.common.cache;
+
+import com.api.readinglog.domain.like.service.LikeSummaryService;
+import com.api.readinglog.domain.summary.entity.Summary;
+import com.api.readinglog.domain.summary.repository.SummaryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CacheInitializer {
+
+    private final LikeSummaryService likeSummaryService;
+    private final SummaryRepository summaryRepository;
+
+    // 서버 재시작 시 캐시의 좋아요 개수를 DB에 초기화
+    @EventListener(ContextRefreshedEvent.class)
+    public void initializeCacheWithSummaries(ContextRefreshedEvent event) {
+        List<Summary> summaries = summaryRepository.findAll();
+
+        summaries.forEach(summary -> {
+            Long summaryId = summary.getId();
+            int likeCount = likeSummaryService.getSummaryLikeCount(summaryId);
+
+            summary.setLikeCount(likeCount);
+            summaryRepository.save(summary);
+        });
+    }
+}

--- a/src/main/java/com/api/readinglog/common/redis/service/RedisService.java
+++ b/src/main/java/com/api/readinglog/common/redis/service/RedisService.java
@@ -1,13 +1,15 @@
 package com.api.readinglog.common.redis.service;
 
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-
 public class RedisService {
 
     private final RedisTemplate<String, Object> redisTemplate;
@@ -17,18 +19,42 @@ public class RedisService {
         redisTemplate.opsForValue().set(key, value.toString(), time, timeUnit);
     }
 
+    public void setLikeData(String userKey, Long summaryId) {
+        redisTemplate.opsForSet().add(userKey, summaryId.toString());
+    }
+
     public Object getData(String key) {
         return redisTemplate.opsForValue().get(key);
     }
-
 
     public void deleteData(String key) {
         redisTemplate.delete(key);
     }
 
+    public void deleteLikeData(String userKey, Long summaryId) {
+        redisTemplate.opsForSet().remove(userKey, summaryId.toString());
+    }
 
-    public void increaseData(String key) {
-        redisTemplate.opsForValue().increment(key);
+    public void increaseLikeCount(String key) {
+        redisTemplate.opsForValue().increment(key, 1);
+    }
+
+    public void decreaseLikeCount(String key) {
+        Integer currentLikeCount = getLikeCount(key);
+
+        if (currentLikeCount == null || currentLikeCount <= 0) {
+            return;
+        }
+        redisTemplate.opsForValue().increment(key, -1);
+    }
+
+    public boolean isPresent(String userKey, Long summaryId) {
+        return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(userKey, summaryId.toString()));
+    }
+
+    public Integer getLikeCount(String key) {
+        Object result = redisTemplate.opsForValue().get(key);
+        return result != null ? (Integer) result : 0;
     }
 
 }

--- a/src/main/java/com/api/readinglog/common/redis/service/RedisService.java
+++ b/src/main/java/com/api/readinglog/common/redis/service/RedisService.java
@@ -27,6 +27,19 @@ public class RedisService {
         return redisTemplate.opsForValue().get(key);
     }
 
+    public Set<Long> getLikeData(String key) {
+        Set<Object> rawData = redisTemplate.opsForSet().members(key);
+
+        if (rawData == null) {
+            return Collections.emptySet();
+        }
+
+        return rawData.stream()
+                .map(Object::toString)
+                .map(Long::parseLong)
+                .collect(Collectors.toSet());
+    }
+
     public void deleteData(String key) {
         redisTemplate.delete(key);
     }

--- a/src/main/java/com/api/readinglog/domain/book/entity/Book.java
+++ b/src/main/java/com/api/readinglog/domain/book/entity/Book.java
@@ -45,7 +45,7 @@ public class Book extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @Column(name = "book_item_id", unique = true)
+    @Column(name = "book_item_id")
     private Integer itemId; // 책 고유 번호
 
     @Column(name = "book_title", nullable = false)

--- a/src/main/java/com/api/readinglog/domain/booklog/service/BookLogService.java
+++ b/src/main/java/com/api/readinglog/domain/booklog/service/BookLogService.java
@@ -8,6 +8,7 @@ import com.api.readinglog.domain.book.service.BookService;
 import com.api.readinglog.domain.booklog.controller.dto.BookLogResponse;
 import com.api.readinglog.domain.highlight.controller.dto.response.HighlightResponse;
 import com.api.readinglog.domain.highlight.repository.HighlightRepository;
+import com.api.readinglog.domain.like.service.LikeSummaryService;
 import com.api.readinglog.domain.member.entity.Member;
 import com.api.readinglog.domain.member.service.MemberService;
 import com.api.readinglog.domain.review.controller.dto.response.ReviewResponse;
@@ -32,6 +33,7 @@ public class BookLogService {
     private final SummaryRepository summaryRepository;
     private final ReviewRepository reviewRepository;
     private final HighlightRepository highlightRepository;
+    private final LikeSummaryService likeSummaryService;
 
     @Transactional(readOnly = true)
     public BookLogResponse myLogs(Long memberId, Long bookId) {
@@ -51,7 +53,8 @@ public class BookLogService {
 
     @Transactional(readOnly = true)
     public Page<SummaryResponse> bookLogs(Pageable pageable) {
-        Page<SummaryResponse> bookLogs = summaryRepository.findAllBy(pageable).map(SummaryResponse::fromEntity);
+        Page<SummaryResponse> bookLogs = summaryRepository.findAllBy(pageable)
+                .map(summary -> SummaryResponse.fromEntity(summary, likeSummaryService.getSummaryLikeCount(summary.getId())));
 
         // 북로그가 존재하지 않는 경우 예외 처리
         if (bookLogs.getContent().isEmpty()) {

--- a/src/main/java/com/api/readinglog/domain/like/service/LikeSummaryService.java
+++ b/src/main/java/com/api/readinglog/domain/like/service/LikeSummaryService.java
@@ -1,0 +1,85 @@
+package com.api.readinglog.domain.like.service;
+
+import com.api.readinglog.common.exception.ErrorCode;
+import com.api.readinglog.common.exception.custom.SummaryException;
+import com.api.readinglog.common.redis.service.RedisService;
+import com.api.readinglog.domain.summary.entity.Summary;
+import com.api.readinglog.domain.summary.repository.SummaryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LikeSummaryService {
+
+    private static final String USER_LIKES_KEY = "user:%s:likes";
+    private static final String SUMMARY_LIKES_KEY = "summary:%s:likes";
+
+    private final RedisService redisService;
+    private final SummaryRepository summaryRepository;
+
+    // 좋아요 등록
+    public void addLikeSummary(Long userId, Long summaryId) {
+        validateSummaryExists(summaryId);
+
+        if (!isLikeAlreadyExists(userId, summaryId)) {
+            String userLikesKey = getUserLikesKey(userId);
+            String summaryLikesKey = getSummaryLikesKey(summaryId);
+
+            redisService.setLikeData(userLikesKey, summaryId);
+            redisService.increaseLikeCount(summaryLikesKey);
+
+            updateSummaryLikeCountInDb(summaryId, 1);
+        }
+    }
+
+    // 좋아요 취소
+    public void deleteLikeSummary(Long userId, Long summaryId) {
+        validateSummaryExists(summaryId);
+
+        if (isLikeAlreadyExists(userId, summaryId)) {
+            String userLikesKey = getUserLikesKey(userId);
+            String summaryLikesKey = getSummaryLikesKey(summaryId);
+
+            redisService.deleteLikeData(userLikesKey, summaryId);
+            redisService.decreaseLikeCount(summaryLikesKey);
+
+            updateSummaryLikeCountInDb(summaryId, -1);
+        }
+    }
+
+    // 좋아요 개수 조회
+    public Integer getSummaryLikeCount(Long summaryId) {
+        return redisService.getLikeCount(getSummaryLikesKey(summaryId));
+    }
+
+    // 유저의 좋아요 존재 여부 확인
+    private boolean isLikeAlreadyExists(Long userId, Long summaryId) {
+        String userLikesKey = getUserLikesKey(userId);
+        return redisService.isPresent(userLikesKey, summaryId);
+    }
+
+    // DB 내 요약 좋아요 개수 업데이트
+    private void updateSummaryLikeCountInDb(Long summaryId, int change) {
+        Summary summary = summaryRepository.findById(summaryId)
+                .orElseThrow(() -> new SummaryException(ErrorCode.NOT_FOUND_SUMMARY));
+        summary.setLikeCount(summary.getLikeCount() + change);
+    }
+
+    // 한 줄평 존재 여부 확인
+    private void validateSummaryExists(Long summaryId) {
+        summaryRepository.findById(summaryId).orElseThrow(
+                () -> new SummaryException(ErrorCode.NOT_FOUND_SUMMARY)
+        );
+    }
+
+    private static String getUserLikesKey(Long userId) {
+        return String.format(USER_LIKES_KEY, userId);
+    }
+
+    private static String getSummaryLikesKey(Long summaryId) {
+        return String.format(SUMMARY_LIKES_KEY, summaryId);
+    }
+}

--- a/src/main/java/com/api/readinglog/domain/member/controller/MemberController.java
+++ b/src/main/java/com/api/readinglog/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.api.readinglog.common.security.util.CookieUtils;
 import com.api.readinglog.domain.email.dto.AuthCodeVerificationRequest;
 import com.api.readinglog.domain.email.dto.EmailRequest;
 import com.api.readinglog.domain.email.service.EmailService;
+import com.api.readinglog.domain.like.service.LikeSummaryService;
 import com.api.readinglog.domain.member.controller.dto.request.DeleteRequest;
 import com.api.readinglog.domain.member.controller.dto.request.JoinNicknameRequest;
 import com.api.readinglog.domain.member.controller.dto.request.JoinRequest;
@@ -15,6 +16,7 @@ import com.api.readinglog.domain.member.controller.dto.request.UpdatePasswordReq
 import com.api.readinglog.domain.member.controller.dto.request.UpdateProfileRequest;
 import com.api.readinglog.domain.member.controller.dto.response.MemberDetailsResponse;
 import com.api.readinglog.domain.member.service.MemberService;
+import com.api.readinglog.domain.summary.controller.dto.response.SummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -25,6 +27,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -47,6 +50,7 @@ public class MemberController {
 
     private final MemberService memberService;
     private final EmailService emailService;
+    private final LikeSummaryService likeSummaryService;
 
     @Operation(summary = "닉네임 중복 검사", description = "회원 가입 전, 닉네임 중복을 검사합니다.",
             parameters = {
@@ -227,5 +231,11 @@ public class MemberController {
                                                 @RequestBody @Valid EmailRequest request) {
         emailService.sendTemporaryPassword(user.getId(), request.getEmail());
         return Response.success(HttpStatus.OK, "임시 비밀번호 전송 완료");
+    }
+
+    @GetMapping("/likes/summaries")
+    public Response<List<SummaryResponse>> getLikeSummaries(@AuthenticationPrincipal CustomUserDetail user) {
+        List<SummaryResponse> likeSummaries = likeSummaryService.getLikeSummaries(user.getId());
+        return Response.success(HttpStatus.OK, "내가 좋아요 한 한줄평 목록 조회", likeSummaries);
     }
 }

--- a/src/main/java/com/api/readinglog/domain/summary/controller/SummaryController.java
+++ b/src/main/java/com/api/readinglog/domain/summary/controller/SummaryController.java
@@ -2,6 +2,7 @@ package com.api.readinglog.domain.summary.controller;
 
 import com.api.readinglog.common.response.Response;
 import com.api.readinglog.common.security.CustomUserDetail;
+import com.api.readinglog.domain.like.service.LikeSummaryService;
 import com.api.readinglog.domain.summary.controller.dto.request.ModifyRequest;
 import com.api.readinglog.domain.summary.controller.dto.request.WriteRequest;
 import com.api.readinglog.domain.summary.service.SummaryService;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class SummaryController {
 
     private final SummaryService summaryService;
+    private final LikeSummaryService likeSummaryService;
 
     @Operation(summary = "Add a new summary", description = "한줄평 작성")
     @PostMapping("/{bookId}")
@@ -55,4 +58,19 @@ public class SummaryController {
         return Response.success(HttpStatus.OK, "한줄평 삭제 성공");
     }
 
+    @Operation(summary = "한 줄평 좋아요 등록", description = "한 줄평 좋아요 등록입니다.")
+    @PostMapping("/likes/{summaryId}")
+    public Response<Void> like(@AuthenticationPrincipal CustomUserDetail user,
+                               @PathVariable Long summaryId) {
+        likeSummaryService.addLikeSummary(user.getId(), summaryId);
+        return Response.success(HttpStatus.OK, "한 줄평 좋아요 등록 성공");
+    }
+
+    @Operation(summary = "한 줄평 좋아요 취소", description = "한 줄평 좋아요 취소입니다.")
+    @DeleteMapping("/likes/{summaryId}")
+    public Response<Void> unlike(@AuthenticationPrincipal CustomUserDetail user,
+                                 @PathVariable Long summaryId) {
+        likeSummaryService.deleteLikeSummary(user.getId(), summaryId);
+        return Response.success(HttpStatus.OK, "한 줄평 좋아요 취소 성공");
+    }
 }

--- a/src/main/java/com/api/readinglog/domain/summary/controller/dto/response/SummaryResponse.java
+++ b/src/main/java/com/api/readinglog/domain/summary/controller/dto/response/SummaryResponse.java
@@ -15,10 +15,9 @@ public class SummaryResponse {
     private String bookCover;
     private String content;
     private LocalDateTime createdAt;
-    // TODO: 좋아요 개수
+    private int likeCount;
 
-
-    public static SummaryResponse fromEntity(Summary summary) {
+    public static SummaryResponse fromEntity(Summary summary, int likeCount) {
         return SummaryResponse.builder()
                 .nickname(summary.getMember().getNickname())
                 .bookTitle(summary.getBook().getTitle())
@@ -26,6 +25,7 @@ public class SummaryResponse {
                 .bookCover(summary.getBook().getCover())
                 .content(summary.getContent())
                 .createdAt(summary.getCreatedAt())
+                .likeCount(likeCount)
                 .build();
     }
 }

--- a/src/main/java/com/api/readinglog/domain/summary/entity/Summary.java
+++ b/src/main/java/com/api/readinglog/domain/summary/entity/Summary.java
@@ -42,11 +42,15 @@ public class Summary extends BaseTimeEntity {
     @Column(name = "summary_content", nullable = false, length = 100)
     private String content;
 
+    @Column(name = "summary_like_count")
+    private Integer likeCount;
+
     @Builder
     private Summary(Member member, Book book, String content) {
         this.member = member;
         this.book = book;
         this.content = content;
+        this.likeCount = 0;
     }
 
     public static Summary of(Member member, Book book, WriteRequest request) {
@@ -59,5 +63,9 @@ public class Summary extends BaseTimeEntity {
 
     public void modify(ModifyRequest request) {
         this.content = request.getContent();
+    }
+
+    public void setLikeCount(Integer likeCount) {
+        this.likeCount = likeCount;
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- closed #83 

## ✅ 작업 상세 내용

- [x] 한 줄평 좋아요 등록 기능
- [x] 한 줄평 좋아요 취소 기능
- [x] 사용자 별 좋아요 등록한 한 줄평 목록 조회 기능
- [x] 서버 재가동 시 캐시와 DB 동기화 기능

## 📌 특이사항

- 서로 다른 사용자가 같은 책을 등록하지 못하는 버그 발견 -> 책 고유 번호의 유니크 설정 삭제로 해결했습니다.
- 서버 재가동 시 캐시의 좋아요 개수와 DB의 좋아요 개수의 동기화 처리 완료했습니다. (안 해줄 경우 데이터 불일치 문제 발생)
- 실제 서비스 상황에서는 좋아요 등록과 취소 동작이 실시간으로 빠르게 요청되기 때문에 이를 캐시에 저장하고 조회 하는 것이 효율적이라고 판단했습니다.
- 캐시에 있는 좋아요 개수를 DB에 또다시 동기화 한 이유는 추후 좋아요 개수에 따른 정렬 기능 시 사용할 예정이기 때문입니다.

## 📝 TODO
- 같은 사용자가 같은 책을 또다시 등록하려고 하는 상황 예외 처리
- 좋아요 개수에 따른 정렬 기능 추가 (페이징)

