### PR TITLE
CacheInitializer 오류 해결

### DIFF
--- a/src/main/java/com/api/readinglog/common/cache/CacheInitializer.java
+++ b/src/main/java/com/api/readinglog/common/cache/CacheInitializer.java
@@ -5,7 +5,7 @@ import com.api.readinglog.domain.summary.entity.Summary;
 import com.api.readinglog.domain.summary.repository.SummaryRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -17,8 +17,8 @@ public class CacheInitializer {
     private final SummaryRepository summaryRepository;
 
     // 서버 재시작 시 캐시의 좋아요 개수를 DB에 초기화
-    @EventListener(ContextRefreshedEvent.class)
-    public void initializeCacheWithSummaries(ContextRefreshedEvent event) {
+    @EventListener(ApplicationReadyEvent.class)
+    public void initializeCacheWithSummaries(ApplicationReadyEvent event) {
         List<Summary> summaries = summaryRepository.findAll();
 
         summaries.forEach(summary -> {


### PR DESCRIPTION
## ✨ 관련 이슈

- closed #86 

## ✅ 작업 상세 내용

- [x] CacheInitializer 빈 주입 순서 오류 발생
- [x] Redis Config Bean 주입 이전에 캐시를 초기화 하는 단계에서 문제 발생
- [x] 캐시 초기화 이벤트 변경 ContextRefreshedEvent -> ApplicationReadyEvent
- [x] 스프링 부트 실행 시 모든 빈의 주입이 끝난 후, 맨 마지막에 캐시 초기화 작업 실행하도록 수정

## 📃 참고 레퍼런스

- [Spring Boot’s Application Events](https://medium.com/@truongbui95/spring-boots-application-events-36ebe09e9313)
