### PR TITLE
북로그 검색 기능 구현

### DIFF
--- a/src/main/java/com/api/readinglog/domain/booklog/controller/BookLogController.java
+++ b/src/main/java/com/api/readinglog/domain/booklog/controller/BookLogController.java
@@ -3,6 +3,8 @@ package com.api.readinglog.domain.booklog.controller;
 import com.api.readinglog.common.response.Response;
 import com.api.readinglog.common.security.CustomUserDetail;
 import com.api.readinglog.domain.booklog.controller.dto.BookLogResponse;
+import com.api.readinglog.domain.booklog.controller.dto.request.BookLogsSearchByBookTitleRequest;
+import com.api.readinglog.domain.booklog.controller.dto.request.BookLogsSearchByCategoryRequest;
 import com.api.readinglog.domain.booklog.service.BookLogService;
 import com.api.readinglog.domain.summary.controller.dto.response.SummaryPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,6 +22,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -55,4 +58,29 @@ public class BookLogController {
         return Response.success(HttpStatus.OK, "북로그 목록 조회 성공", bookLogService.bookLogs(pageable));
     }
 
+    @Operation(summary = "북로그 책 제목으로 검색", description = "책 제목을 통해 북로그 목록을 조회합니다. 기본값은 최신순 정렬입니다. 정렬 조건을 추가하면 인기순 정렬이 가능합니다. 비회원도 조회가 가능합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "북로그 책 제목 검색 성공",
+                    content = {@Content(schema = @Schema(implementation = Response.class))}),
+            @ApiResponse(responseCode = "404", description = "북로그 목록이 존재하지 않습니다!")
+    })
+    @GetMapping("/search/title")
+    public Response<SummaryPageResponse> findBookLogsByBookTitle(@RequestBody BookLogsSearchByBookTitleRequest request,
+                                                                 @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+        return Response.success(HttpStatus.OK, "북로그 책 제목 검색 성공",
+                bookLogService.findBookLogsByBookTitle(request, pageable));
+    }
+
+    @Operation(summary = "북로그 책 카테고리명으로 검색", description = "책 카테고리명을 통해 북로그 목록을 조회합니다. 기본값은 최신순 정렬입니다. 정렬 조건을 추가하면 인기순 정렬이 가능합니다. 비회원도 조회가 가능합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "북로그 책 카테고리명 검색 성공",
+                    content = {@Content(schema = @Schema(implementation = Response.class))}),
+            @ApiResponse(responseCode = "404", description = "북로그 목록이 존재하지 않습니다!")
+    })
+    @GetMapping("/search/category")
+    public Response<SummaryPageResponse> findBookLogsByCategory(@RequestBody BookLogsSearchByCategoryRequest request,
+                                                                @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+        return Response.success(HttpStatus.OK, "북로그 책 카테고리명 검색 성공",
+                bookLogService.findBookLogsByCategory(request, pageable));
+    }
 }

--- a/src/main/java/com/api/readinglog/domain/booklog/controller/BookLogController.java
+++ b/src/main/java/com/api/readinglog/domain/booklog/controller/BookLogController.java
@@ -4,7 +4,7 @@ import com.api.readinglog.common.response.Response;
 import com.api.readinglog.common.security.CustomUserDetail;
 import com.api.readinglog.domain.booklog.controller.dto.BookLogResponse;
 import com.api.readinglog.domain.booklog.service.BookLogService;
-import com.api.readinglog.domain.summary.controller.dto.response.SummaryResponse;
+import com.api.readinglog.domain.summary.controller.dto.response.SummaryPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "BookLogs", description = "북로그 API 목록입니다.")
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 @RequestMapping("/api/book-logs")
 public class BookLogController {
 
@@ -43,16 +44,15 @@ public class BookLogController {
         return Response.success(HttpStatus.OK, "나의 로그 조회 성공", bookLogService.myLogs(user.getId(), bookId));
     }
 
-    @Operation(summary = "북로그 조회", description = "리딩 로그 서비스의 모든 북로그를 조회합니다. 비회원도 조회가 가능합니다.")
+    @Operation(summary = "북로그 목록 조회", description = "리딩 로그 서비스의 전체 북로그 목록을 조회합니다. 기본값은 최신순 정렬입니다. 정렬 조건을 추가하면 인기순 정렬이 가능합니다. 비회원도 조회가 가능합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "북로그 조회 성공",
+            @ApiResponse(responseCode = "200", description = "북로그 목록 조회 성공",
                     content = {@Content(schema = @Schema(implementation = Response.class))}),
             @ApiResponse(responseCode = "404", description = "북로그 목록이 존재하지 않습니다!")
     })
     @GetMapping
-    public Response<Page<SummaryResponse>> bookLogs(@PageableDefault(sort = "createdAt", direction = Direction.DESC)
-                                                    Pageable pageable) {
-        // TODO: querydsl 동적 쿼리 처리
-        return Response.success(HttpStatus.OK, "북로그 조회 성공", bookLogService.bookLogs(pageable));
+    public Response<SummaryPageResponse> bookLogs(@PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+        return Response.success(HttpStatus.OK, "북로그 목록 조회 성공", bookLogService.bookLogs(pageable));
     }
+
 }

--- a/src/main/java/com/api/readinglog/domain/booklog/controller/BookLogController.java
+++ b/src/main/java/com/api/readinglog/domain/booklog/controller/BookLogController.java
@@ -44,7 +44,7 @@ public class BookLogController {
     @GetMapping("/{bookId}/me")
     public Response<BookLogResponse> myLogs(@AuthenticationPrincipal CustomUserDetail user,
                                             @PathVariable Long bookId) {
-        return Response.success(HttpStatus.OK, "나의 로그 조회 성공", bookLogService.myLogs(user.getId(), bookId));
+        return Response.success(HttpStatus.OK, "나의 로그 조회 성공", bookLogService.bookLogDetails(user.getId(), bookId));
     }
 
     @Operation(summary = "북로그 목록 조회", description = "리딩 로그 서비스의 전체 북로그 목록을 조회합니다. 기본값은 최신순 정렬입니다. 정렬 조건을 추가하면 인기순 정렬이 가능합니다. 비회원도 조회가 가능합니다.")
@@ -54,8 +54,21 @@ public class BookLogController {
             @ApiResponse(responseCode = "404", description = "북로그 목록이 존재하지 않습니다!")
     })
     @GetMapping
-    public Response<SummaryPageResponse> bookLogs(@PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+    public Response<SummaryPageResponse> bookLogs(
+            @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
         return Response.success(HttpStatus.OK, "북로그 목록 조회 성공", bookLogService.bookLogs(pageable));
+    }
+
+    @Operation(summary = "북로그 상세 조회", description = "북로그 상세 조회입니다. 회원과 책 ID값을 통해 조회할 수 있습니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "북로그 상세 조회 성공",
+                    content = {@Content(schema = @Schema(implementation = Response.class))}),
+            @ApiResponse(responseCode = "400", description = "북로그 상세 조회 실패")
+    })
+    @GetMapping("/{bookId}/{memberId}")
+    public Response<BookLogResponse> bookLogsDetails(@PathVariable Long bookId,
+                                                     @PathVariable Long memberId) {
+        return Response.success(HttpStatus.OK, "북로그 상세 조회 성공", bookLogService.bookLogDetails(memberId, bookId));
     }
 
     @Operation(summary = "북로그 책 제목으로 검색", description = "책 제목을 통해 북로그 목록을 조회합니다. 기본값은 최신순 정렬입니다. 정렬 조건을 추가하면 인기순 정렬이 가능합니다. 비회원도 조회가 가능합니다.")

--- a/src/main/java/com/api/readinglog/domain/booklog/controller/dto/request/BookLogsSearchByBookTitleRequest.java
+++ b/src/main/java/com/api/readinglog/domain/booklog/controller/dto/request/BookLogsSearchByBookTitleRequest.java
@@ -1,0 +1,12 @@
+package com.api.readinglog.domain.booklog.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class BookLogsSearchByBookTitleRequest {
+
+    @Schema(description = "책 제목 검색어")
+    private String bookTitle;
+
+}

--- a/src/main/java/com/api/readinglog/domain/booklog/controller/dto/request/BookLogsSearchByCategoryRequest.java
+++ b/src/main/java/com/api/readinglog/domain/booklog/controller/dto/request/BookLogsSearchByCategoryRequest.java
@@ -1,0 +1,11 @@
+package com.api.readinglog.domain.booklog.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class BookLogsSearchByCategoryRequest {
+
+    @Schema(description = "카테고리명 검색어")
+    private String categoryName;
+}

--- a/src/main/java/com/api/readinglog/domain/booklog/service/BookLogService.java
+++ b/src/main/java/com/api/readinglog/domain/booklog/service/BookLogService.java
@@ -42,9 +42,9 @@ public class BookLogService {
     private final HighlightRepository highlightRepository;
     private final LikeSummaryService likeSummaryService;
 
-    // 나의 로그 조회
+    // 북로그 상세 조회
     @Transactional(readOnly = true)
-    public BookLogResponse myLogs(Long memberId, Long bookId) {
+    public BookLogResponse bookLogDetails(Long memberId, Long bookId) {
         Member member = getMember(memberId);
         Book book = getBook(bookId);
         BookDetailResponse bookDetailResponse = bookService.getBookInfo(memberId, bookId);
@@ -59,7 +59,7 @@ public class BookLogService {
         return BookLogResponse.of(bookDetailResponse, summary, reviews, highlights);
     }
 
-    // 북로그 목록 조회
+    // 북로그 전체 목록 조회
     @Transactional(readOnly = true)
     public SummaryPageResponse bookLogs(Pageable pageable) {
         Slice<Summary> summaries = summaryRepository.findAllBy(pageable);
@@ -75,12 +75,6 @@ public class BookLogService {
                 .collect(Collectors.toList());
 
         return SummaryPageResponse.fromSlice(bookLogs, summaries.hasNext());
-    }
-
-    // TODO: 북로그 상세 조회 (책, 회원, 한줄평, 서평, 하이라이트 모두)
-    @Transactional(readOnly = true)
-    public BookLogResponse bookLogDetails() {
-        return null;
     }
 
     // 책 제목으로 검색

--- a/src/main/java/com/api/readinglog/domain/summary/controller/dto/response/MySummaryResponse.java
+++ b/src/main/java/com/api/readinglog/domain/summary/controller/dto/response/MySummaryResponse.java
@@ -9,12 +9,14 @@ import lombok.Getter;
 @Builder
 public class MySummaryResponse {
 
+    private String nickname;
     private String content;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
     public static MySummaryResponse fromEntity(Summary summary) {
         return MySummaryResponse.builder()
+                .nickname(summary.getMember().getNickname())
                 .content(summary.getContent())
                 .createdAt(summary.getCreatedAt())
                 .modifiedAt(summary.getModifiedAt())

--- a/src/main/java/com/api/readinglog/domain/summary/controller/dto/response/SummaryPageResponse.java
+++ b/src/main/java/com/api/readinglog/domain/summary/controller/dto/response/SummaryPageResponse.java
@@ -1,0 +1,24 @@
+package com.api.readinglog.domain.summary.controller.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SummaryPageResponse {
+    private List<SummaryResponse> content;
+    private boolean hasNext;
+
+    @Builder
+    private SummaryPageResponse(List<SummaryResponse> content, boolean hasNext) {
+        this.content = content;
+        this.hasNext = hasNext;
+    }
+
+    public static SummaryPageResponse fromSlice(List<SummaryResponse> content, boolean hasNext) {
+        return SummaryPageResponse.builder()
+                .content(content)
+                .hasNext(hasNext)
+                .build();
+    }
+}

--- a/src/main/java/com/api/readinglog/domain/summary/controller/dto/response/SummaryResponse.java
+++ b/src/main/java/com/api/readinglog/domain/summary/controller/dto/response/SummaryResponse.java
@@ -9,7 +9,9 @@ import lombok.Getter;
 @Builder
 public class SummaryResponse {
 
+    private Long memberId;
     private String nickname;
+    private Long bookId;
     private String bookTitle;
     private String bookAuthor;
     private String bookCover;
@@ -19,7 +21,9 @@ public class SummaryResponse {
 
     public static SummaryResponse fromEntity(Summary summary, int likeCount) {
         return SummaryResponse.builder()
+                .memberId(summary.getMember().getId())
                 .nickname(summary.getMember().getNickname())
+                .bookId(summary.getBook().getId())
                 .bookTitle(summary.getBook().getTitle())
                 .bookAuthor(summary.getBook().getAuthor())
                 .bookCover(summary.getBook().getCover())

--- a/src/main/java/com/api/readinglog/domain/summary/repository/CustomSummaryRepository.java
+++ b/src/main/java/com/api/readinglog/domain/summary/repository/CustomSummaryRepository.java
@@ -1,0 +1,12 @@
+package com.api.readinglog.domain.summary.repository;
+
+import com.api.readinglog.domain.summary.entity.Summary;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomSummaryRepository {
+
+    List<Summary> findByBookTitle(String bookTitle, Pageable pageable);
+
+    List<Summary> findByCategoryName(String categoryTitle, Pageable pageable);
+}

--- a/src/main/java/com/api/readinglog/domain/summary/repository/CustomSummaryRepositoryImpl.java
+++ b/src/main/java/com/api/readinglog/domain/summary/repository/CustomSummaryRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.api.readinglog.domain.summary.repository;
+
+import static com.api.readinglog.domain.book.entity.QBook.book;
+import static com.api.readinglog.domain.summary.entity.QSummary.summary;
+
+import com.api.readinglog.domain.summary.entity.Summary;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+public class CustomSummaryRepositoryImpl implements CustomSummaryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Summary> findByBookTitle(String bookTitle, Pageable pageable) {
+        return queryFactory
+                .select(summary)
+                .from(summary)
+                .join(summary.book, book)
+                .where(book.title.contains(bookTitle)) // 검색어를 포함
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1) // 다음 페이지 존재 여부 판별
+                .fetch();
+    }
+
+    @Override
+    public List<Summary> findByCategoryName(String categoryTitle, Pageable pageable) {
+        return queryFactory
+                .select(summary)
+                .from(summary)
+                .join(summary.book, book)
+                .where(book.category.eq(categoryTitle)) // 검색어와 일치
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1) // 다음 페이지 존재 여부 판별
+                .fetch();
+    }
+}

--- a/src/main/java/com/api/readinglog/domain/summary/repository/SummaryRepository.java
+++ b/src/main/java/com/api/readinglog/domain/summary/repository/SummaryRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SummaryRepository extends JpaRepository<Summary, Long> {
+public interface SummaryRepository extends JpaRepository<Summary, Long>, CustomSummaryRepository {
 
     Optional<Summary> findByMemberAndBook(Member member, Book book);
 


### PR DESCRIPTION
## ✨ 관련 이슈

- closed #98 

## ✅ 작업 상세 내용

- [x] 북로그 목록 조회 무한스크롤 변경
- [x] 북로그 책 제목 검색 기능 구현
- [x] 북로그 카테고리명 검색 기능 구현
- [x] 나의 로그 조회 API Response Body 닉네임 값 추가
- [x] 북로그 목록 조회 API Response Body 회원 id, 책 id 값 추가
- [x] 북로그 상세 조회 기능 구현

## 📌 특이사항

- TODO: 무한스크롤 테스트용 더미데이터 추가

## 📃 참고 레퍼런스

- [Spring 무한스크롤 페이징 기능 구현 + no offset(Querydsl)](https://velog.io/@sgb8170/Spring-%EB%AC%B4%ED%95%9C%EC%8A%A4%ED%81%AC%EB%A1%A4-%ED%8E%98%EC%9D%B4%EC%A7%95-%EA%B8%B0%EB%8A%A5-%EA%B5%AC%ED%98%84-no-offsetQuerydsl)
