### PR TITLE
책 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/api/readinglog/domain/book/controller/BookController.java
+++ b/src/main/java/com/api/readinglog/domain/book/controller/BookController.java
@@ -1,10 +1,13 @@
 package com.api.readinglog.domain.book.controller;
 
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
 import com.api.readinglog.common.response.Response;
 import com.api.readinglog.common.security.CustomUserDetail;
 import com.api.readinglog.domain.book.dto.BookDetailResponse;
 import com.api.readinglog.domain.book.dto.BookDirectRequest;
 import com.api.readinglog.domain.book.dto.BookRegisterRequest;
+import com.api.readinglog.domain.book.dto.BookResponse;
 import com.api.readinglog.domain.book.dto.BookSearchApiResponse;
 import com.api.readinglog.domain.book.dto.BookModifyRequest;
 import com.api.readinglog.domain.book.service.BookService;
@@ -13,6 +16,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -35,6 +42,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class BookController {
 
     private final BookService bookService;
+
+    @GetMapping("/me")
+    public Response<Page<BookResponse>> myBookList(@AuthenticationPrincipal CustomUserDetail user,
+                                     @RequestParam(required = false) String keyword,
+                                     @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
+
+        Page<BookResponse> response = bookService.myBookList(user.getId(), keyword, pageable);
+        return Response.success(HttpStatus.OK, "내가 등록한 책 목록 조회 성공", response);
+    }
 
     @Operation(summary = "등록한 책 조회", description = "사용자가 등록한 책 정보를 조회합니다.")
     @GetMapping("/{bookId}")

--- a/src/main/java/com/api/readinglog/domain/book/dto/BookResponse.java
+++ b/src/main/java/com/api/readinglog/domain/book/dto/BookResponse.java
@@ -1,0 +1,18 @@
+package com.api.readinglog.domain.book.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BookResponse {
+
+    private Long bookId;
+    private Long memberId;
+    private String cover;
+    private String title;
+    private String author;
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/api/readinglog/domain/book/dto/BookSearchApiResponse.java
+++ b/src/main/java/com/api/readinglog/domain/book/dto/BookSearchApiResponse.java
@@ -10,8 +10,10 @@ import lombok.Setter;
 public class BookSearchApiResponse {
 
     private int totalResults; // 전체 데이터 개수
-    private int startIndex; // 시작 페이지
     private int itemsPerPage; // 페이지당 아이템 개수
+    private int totalPage; // 전체 페이지수
+    private int startIndex; // 시작 페이지
+    private boolean hasNext; // 다음 페이지 존재 여부
     private String query; // 검색어
 
     private List<Item> item = new ArrayList<>();

--- a/src/main/java/com/api/readinglog/domain/book/repository/CustomBookRepository.java
+++ b/src/main/java/com/api/readinglog/domain/book/repository/CustomBookRepository.java
@@ -2,11 +2,16 @@ package com.api.readinglog.domain.book.repository;
 
 import com.api.readinglog.domain.book.dto.BookCalendarResponse;
 import com.api.readinglog.domain.book.dto.BookCategoryResponse;
+import com.api.readinglog.domain.book.dto.BookResponse;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface CustomBookRepository {
 
-    Long getBookTotalCountInMonth(long memberId, int month);
+    Page<BookResponse> myBookList(Long memberId, String keyword, Pageable pageable);
+
+    Long getBookTotalCountInMonth(Long memberId, int month);
 
     List<BookCategoryResponse> getBookCountGroupByCategoryInMonth(Long memberId, int month);
 

--- a/src/main/java/com/api/readinglog/domain/book/repository/CustomBookRepositoryImpl.java
+++ b/src/main/java/com/api/readinglog/domain/book/repository/CustomBookRepositoryImpl.java
@@ -4,10 +4,20 @@ import static com.api.readinglog.domain.book.entity.QBook.book;
 
 import com.api.readinglog.domain.book.dto.BookCalendarResponse;
 import com.api.readinglog.domain.book.dto.BookCategoryResponse;
+import com.api.readinglog.domain.book.dto.BookResponse;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 @RequiredArgsConstructor
 public class CustomBookRepositoryImpl implements CustomBookRepository{
@@ -15,7 +25,35 @@ public class CustomBookRepositoryImpl implements CustomBookRepository{
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Long getBookTotalCountInMonth(long memberId, int month) {
+    public Page<BookResponse> myBookList(Long memberId, String keyword, Pageable pageable) {
+
+        List<BookResponse> response = queryFactory.select(Projections.constructor(
+                        BookResponse.class, book.id, book.member.id, book.cover, book.title, book.author, book.createdAt)
+                )
+                .from(book)
+                .where(book.member.id.eq(memberId), containKeyword(keyword))
+                .orderBy(getAllOrderSpecifiers(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long count = queryFactory.select(book.count())
+                .from(book)
+                .where(book.member.id.eq(memberId), containKeyword(keyword))
+                .fetchFirst();
+
+        return new PageImpl<>(response, pageable, count);
+    }
+
+    private BooleanExpression containKeyword(String keyword) {
+        if(keyword == null || keyword.isEmpty()) {
+            return null;
+        }
+        return book.title.containsIgnoreCase(keyword);
+    }
+
+    @Override
+    public Long getBookTotalCountInMonth(Long memberId, int month) {
         return queryFactory
                 .select(book.count())
                 .from(book)
@@ -42,5 +80,19 @@ public class CustomBookRepositoryImpl implements CustomBookRepository{
                 .where(book.member.id.eq(memberId).and(book.createdAt.month().eq(month)))
                 .orderBy(book.createdAt.asc())
                 .fetch();
+    }
+
+    private OrderSpecifier<?>[] getAllOrderSpecifiers(Pageable pageable) {
+        List<OrderSpecifier<?>> orderSpecifierList = new ArrayList<>();
+
+        for (Sort.Order order : pageable.getSort()) {
+            Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+
+            switch (order.getProperty()) {
+                case "createdAt" -> orderSpecifierList.add(new OrderSpecifier<>(direction, book.createdAt));
+            }
+        }
+
+        return orderSpecifierList.toArray(OrderSpecifier[]::new);
     }
 }

--- a/src/main/java/com/api/readinglog/domain/book/service/BookService.java
+++ b/src/main/java/com/api/readinglog/domain/book/service/BookService.java
@@ -61,7 +61,7 @@ public class BookService {
             throw new BookException(ErrorCode.EMPTY_SEARCH_KEYWORD);
         }
 
-        return webClient.get()
+        BookSearchApiResponse response = webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/ItemSearch.aspx")
                         .queryParam("Query", query)
@@ -75,6 +75,20 @@ public class BookService {
                 .retrieve()
                 .bodyToMono(BookSearchApiResponse.class)
                 .block();
+
+        // 다음 페이지 존재 여부
+        int totalResults = response.getTotalResults();
+        int itemsPerPage = response.getItemsPerPage();
+        int totalPage = totalResults / itemsPerPage == 0 ? totalResults / itemsPerPage : (totalResults / itemsPerPage) + 1;
+        int startIndex = response.getStartIndex(); // 현재 페이지
+
+        // 현재 페이지가 전체 페이지보다 작으면 다음 페이지 존재
+        if (startIndex < totalPage) {
+            response.setHasNext(true);
+        }
+        response.setTotalPage(totalPage);
+
+        return response;
     }
 
     // 책 자동 등록

--- a/src/main/java/com/api/readinglog/domain/book/service/BookService.java
+++ b/src/main/java/com/api/readinglog/domain/book/service/BookService.java
@@ -10,6 +10,7 @@ import com.api.readinglog.domain.book.dto.BookDetailResponse;
 import com.api.readinglog.domain.book.dto.BookDirectRequest;
 import com.api.readinglog.domain.book.dto.BookModifyRequest;
 import com.api.readinglog.domain.book.dto.BookRegisterRequest;
+import com.api.readinglog.domain.book.dto.BookResponse;
 import com.api.readinglog.domain.book.dto.BookSearchApiResponse;
 import com.api.readinglog.domain.book.entity.Book;
 import com.api.readinglog.domain.book.repository.BookRepository;
@@ -17,6 +18,8 @@ import com.api.readinglog.domain.member.entity.Member;
 import com.api.readinglog.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -31,6 +34,12 @@ public class BookService {
     private final BookRepository bookRepository;
     private final MemberService memberService;
     private final AmazonS3Service amazonS3Service;
+
+    @Transactional(readOnly = true)
+    public Page<BookResponse> myBookList(Long memberId, String keyword, Pageable pageable) {
+        Member member = memberService.getMemberById(memberId);
+        return bookRepository.myBookList(memberId, keyword, pageable);
+    }
 
     @Transactional(readOnly = true)
     public BookDetailResponse getBookInfo(Long memberId, Long bookId) {
@@ -111,4 +120,5 @@ public class BookService {
     public Book getBookById(Long bookId) {
         return bookRepository.findById(bookId).orElseThrow(() -> new BookException(ErrorCode.NOT_FOUND_BOOK));
     }
+
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- closed #100 

## ✅ 작업 상세 내용

- [x] 내가 등록한 책 목록 조회 기능 구현 (최신순으로 조회)
- [x] 책 검색 응답 결과에 `다음 페이지 존재 여부`, `전체 페이지 수` 추가
  - 무한 스크롤 처리를 위한 데이터

## 📃 참고 레퍼런스
- [[Querydsl]동적 sorting을 위한 OrderSpecifier 클래스 구현](https://velog.io/@seungho1216/Querydsl%EB%8F%99%EC%A0%81-sorting%EC%9D%84-%EC%9C%84%ED%95%9C-OrderSpecifier-%ED%81%B4%EB%9E%98%EC%8A%A4-%EA%B5%AC%ED%98%84)
